### PR TITLE
Add 'firsts' column to results + refactor results page

### DIFF
--- a/Assets/lang/en.json
+++ b/Assets/lang/en.json
@@ -288,9 +288,9 @@
                 "title": "TITLE",
                 "artist": "ARTIST",
                 "hoster": "HOST",
-                "totalVotes": "VOTES",
+                "totalVotes": "TOTAL VOTES",
                 "username": "USER",
-                "firstChoice": "FIRSTS"
+                "firstChoice": "FIRST CHOICES"
             },
             "resultsOverlay": "Hello! This is possibly the first time you have navigated to the results page! <br> These results show the final placements of the beatmaps/users using <a href='https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/IRV_counting_flowchart.svg/300px-IRV_counting_flowchart.svg.png'>ranked choice voting,</a> alongside the amount of times the beatmap/user was a first choice, and the total number of appearances!<br> Hopefully these results for MCA [YEAR] are to your liking! Can't wait to see you all for next MCA!"
         }

--- a/Assets/lang/en.json
+++ b/Assets/lang/en.json
@@ -282,14 +282,14 @@
             "userID": "USER ID"
         },
         "results": {
-            "place": "PLACE",
+            "placement": "PLACE",
             "map": "MAP",
             "title": "TITLE",
             "artist": "ARTIST",
-            "host": "HOST",
-            "votes": "VOTES",
-            "user": "USER",
-            "firsts": "FIRSTS"
+            "hoster": "HOST",
+            "totalVotes": "VOTES",
+            "username": "USER",
+            "firstChoice": "FIRSTS"
         }
     },
     "main": {

--- a/Assets/lang/en.json
+++ b/Assets/lang/en.json
@@ -288,7 +288,8 @@
             "artist": "ARTIST",
             "host": "HOST",
             "votes": "VOTES",
-            "user": "USER"
+            "user": "USER",
+            "firsts": "FIRSTS"
         }
     },
     "main": {

--- a/Assets/lang/en.json
+++ b/Assets/lang/en.json
@@ -282,14 +282,17 @@
             "userID": "USER ID"
         },
         "results": {
-            "placement": "PLACE",
-            "map": "MAP",
-            "title": "TITLE",
-            "artist": "ARTIST",
-            "hoster": "HOST",
-            "totalVotes": "VOTES",
-            "username": "USER",
-            "firstChoice": "FIRSTS"
+            "headings": {
+                "placement": "PLACE",
+                "map": "MAP",
+                "title": "TITLE",
+                "artist": "ARTIST",
+                "hoster": "HOST",
+                "totalVotes": "VOTES",
+                "username": "USER",
+                "firstChoice": "FIRSTS"
+            },
+            "resultsOverlay": "Hello! This is possibly the first time you have navigated to the results page! <br> These results show the final placements of the beatmaps/users using <a href='https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/IRV_counting_flowchart.svg/300px-IRV_counting_flowchart.svg.png'>ranked choice voting,</a> alongside the amount of times the beatmap/user was a first choice, and the total number of appearances!<br> Hopefully these results for MCA [YEAR] are to your liking! Can't wait to see you all for next MCA!"
         }
     },
     "main": {

--- a/Interfaces/result.ts
+++ b/Interfaces/result.ts
@@ -2,6 +2,7 @@ import { BeatmapsetInfo } from "./beatmap";
 import { CategoryType } from "./category";
 import { UserChoiceInfo } from "./user";
 import { ResultVote } from "./vote";
+import { SectionCategory } from "../MCA-AYIM/store/stage";
 
 export interface BeatmapResult extends BeatmapsetInfo {
     placement: number,
@@ -15,6 +16,18 @@ export interface UserResult extends UserChoiceInfo {
     firstChoice: number,
     votes: number,
     totalVotes: number,
+}
+
+export interface ResultColumn {
+    label?: string,
+    name?: string,
+    size: number,
+    msize?: number,
+    category?: SectionCategory,
+    mobileOnly?: boolean,
+    desktopOnly?: boolean,
+    centred?: boolean,
+    prio?: boolean
 }
 
 export function votesToResults(votes: ResultVote[], categoryType: CategoryType): BeatmapResult[] | UserResult[] {

--- a/MCA-AYIM/components/header/LoginModal.vue
+++ b/MCA-AYIM/components/header/LoginModal.vue
@@ -66,7 +66,6 @@ export default class LoginModal extends Vue {
     @Prop({ type: String, required: true }) readonly site!: string;
 
     close () {
-        console.log(this.$router);
         this.$emit("close");
     }
 

--- a/MCA/components/results/ResultsBeatmapsetCard.vue
+++ b/MCA/components/results/ResultsBeatmapsetCard.vue
@@ -8,7 +8,7 @@
                 target="_blank"
             >
                 <template
-                    v-for="(col, i) in filtCol"
+                    v-for="(col, i) in columns"
                 >   
                     <!-- special output for aggregation of map info on mobile -->
                     <div
@@ -69,16 +69,6 @@ export default class ResultsBeatmapsetCard extends Vue {
             return {'flex': col.msize};
         }
         return {'flex': col.size};
-    }
-
-    // filter columns prop by breakpoint and category
-    get filtCol() {
-        return this.columns.filter(
-            c => (!c.category || c.category === "beatmaps") &&
-            ((c.mobileOnly && this.mobile) || 
-             (c.desktopOnly && !this.mobile) ||
-             (!c.mobileOnly && !c.desktopOnly))
-        );
     }
 
     get bgImg (): any {

--- a/MCA/components/results/ResultsBeatmapsetCard.vue
+++ b/MCA/components/results/ResultsBeatmapsetCard.vue
@@ -33,9 +33,11 @@
                     <span
                         v-else
                         :key="i"
-                        :class="((col.name) ? `map-info__${col.name}` : `map-info__${col.label}`) +
-                                 ((col.centred) ? ' map-info__centred' : '') + 
-                                 ((col.prio) ? ' map-info__prio' : '')"
+                        :class="[
+                            col.name ? `map-info__${col.name}` : `map-info__${col.label}`,
+                            { 'map-info__centred': col.centred }, 
+                            { 'map-info__prio': col.prio }
+                        ]"
                         :style="{'flex': `${mobile && col.msize ? col.msize : col.size}`}"
                     >
                         {{ col.label ? choice[col.label] : "" }}
@@ -64,7 +66,6 @@ export default class ResultsBeatmapsetCard extends Vue {
             c => ((c.label === label) || (c.name && c.name === label))
             && (c.category === "beatmaps" || !c.category)
         )[0];
-        console.log(col, label);
         if (this.mobile && col.msize) {
             return {'flex': col.msize};
         }

--- a/MCA/components/results/ResultsBeatmapsetCard.vue
+++ b/MCA/components/results/ResultsBeatmapsetCard.vue
@@ -22,7 +22,8 @@
                 <span class="map-info__title">{{ choice.title }}</span>
                 <span class="map-info__artist">{{ choice.artist }}</span>
                 <span class="map-info__host">{{ choice.hoster }}</span>
-                <span class="map-info__votes">{{ choice.votes }}</span>
+                <span class="map-info__firsts">{{ choice.firstChoice }}</span>
+                <span class="map-info__votes">{{ choice.totalVotes }}</span>
                 <span class="map-info__vote-right" />
             </a>
         </div>
@@ -31,10 +32,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from "vue-property-decorator";
+import { BeatmapResult } from "../../../Interfaces/result";
 
 @Component
 export default class ResultsBeatmapsetCard extends Vue {
-    @Prop({ type: Object, default: () => ({}) }) readonly choice!: Record<string, any>;
+    @Prop({ type: Object, default: () => ({}) }) readonly choice!: BeatmapResult;
 
     get bgImg (): any {
         if (this.choice)
@@ -83,16 +85,6 @@ export default class ResultsBeatmapsetCard extends Vue {
     color: white;
     text-decoration: none;
 
-    &__place {
-        min-width: 3rem;
-        flex: 2;
-        display: flex;
-        align-items: center;
-        text-shadow: 0 0 4px white;
-        font-size: $font-lg;
-        @extend %text-wrap;
-    }
-
     &__title {
         display: none;
         @extend %text-wrap;
@@ -123,7 +115,7 @@ export default class ResultsBeatmapsetCard extends Vue {
     }
 
     &__map {
-        flex: 11;
+        flex: 6;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -179,12 +171,39 @@ export default class ResultsBeatmapsetCard extends Vue {
 
         @include breakpoint(tablet) {
             display: inline;
-            flex: 4;
+            flex: 2.25;
             margin-right: auto;
             text-shadow: 0 0 4px rgba(255,255,255,0.6);
             font-size: $font-lg;
             box-sizing: border-box;
             padding-right: 8px;
+        }
+    }
+
+    &__place {
+        min-width: 3rem;
+        flex: 1.5;
+        display: flex;
+        align-items: center;
+        text-shadow: 0 0 4px white;
+        font-size: $font-lg;
+        @extend %text-wrap;
+    }
+
+    &__firsts {
+        display: none;
+        @extend %text-wrap;
+
+        @include breakpoint(tablet) {
+            min-width: 3rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            text-shadow: 0 0 4px white;
+            font-size: $font-lg;
+            
+            flex: 1.5;
         }
     }
 

--- a/MCA/components/results/ResultsFilters.vue
+++ b/MCA/components/results/ResultsFilters.vue
@@ -104,16 +104,16 @@ export default class ResultsFilters extends Vue {
 
     // dropdown styles
     get catTypeStyle () {
+        const longestStr = Math.max(...this.localCatTypes.map(lct => lct.toString().length));
         return {
-            'width': `${Math.max(85 + Math.max(...this.localCatTypes.map(lct => lct.toString().length)) * 10, 165)}px`,
+            'width': `${longestStr * 0.82}em`,
         }
     }
 
     get catStyle () {
+        const longestStr = Math.max(...this.categoriesInfo.map(c => this.$t(`mca.categories.${c.name}.name`).toString().length));
         return {
-            'width': `${Math.max(85 + Math.max(...this.categoriesInfo.map(c => this.$t(`mca.categories.${c.name}.name`).toString().length)) * 10, 165)}px`,
-            // formula to estimate box width from character count
-            // flat factor (85) and scaling factor (10) are pretty arbitrary  
+            'width': `${longestStr * 0.82}em`,
             'clip-path': 'inset(-8px -8px -8px 0)'
         }
     }

--- a/MCA/components/results/ResultsFilters.vue
+++ b/MCA/components/results/ResultsFilters.vue
@@ -138,6 +138,10 @@ export default class ResultsFilters extends Vue {
 @import '@s-sass/_mixins';
 @import '@s-sass/_partials';
 
+// this determines the width of stage-page-filters at which it wraps below
+//   the dropdowns
+$two-row-breakpoint: 56rem;
+
 .results-filters {
     top: 30%;
     flex: initial;
@@ -209,7 +213,7 @@ export default class ResultsFilters extends Vue {
     @include breakpoint(laptop) {
         flex: 10;
         max-height: 85px;
-        min-width: 56rem;
+        min-width: $two-row-breakpoint;
     }
 }
 </style>

--- a/MCA/components/results/ResultsTableHeadings.vue
+++ b/MCA/components/results/ResultsTableHeadings.vue
@@ -1,0 +1,135 @@
+<template>    
+    <span 
+        v-if="section === 'beatmaps'"
+        class="table-headings"
+    >
+        <span class="table-headings__mapplace">{{ $t('mca.results.place') }}</span>
+        <span class="table-headings__map">{{ $t('mca.results.map') }}</span>
+        <span class="table-headings__title">{{ $t('mca.results.title') }}</span>
+        <span class="table-headings__artist">{{ $t('mca.results.artist') }}</span>
+        <span class="table-headings__host">{{ $t('mca.results.host') }}</span>
+        <span class="table-headings__firsts">{{ $t('mca.results.firsts') }}</span>
+        <span class="table-headings__votes">{{ $t('mca.results.votes') }}</span>
+        <span class="table-headings__vote-right" />
+    </span>
+    <span
+        v-else
+        class="table-headings"
+    >
+        <span class="table-headings__userplace">{{ $t('mca.results.place') }}</span>
+        <span class="table-headings__user">{{ $t('mca.results.user') }}</span>
+        <span class="table-headings__firsts">{{ $t('mca.results.firsts') }}</span>
+        <span class="table-headings__votes">{{ $t('mca.results.votes') }}</span>
+        <span class="table-headings__vote-right" />
+    </span>
+</template>
+
+<script lang="ts">
+import { Vue, Prop, Component } from "vue-property-decorator";
+
+@Component({})
+export default class ResultsFilters extends Vue {
+    @Prop({ type: String, default: ""}) readonly section!: string;
+}
+</script>
+
+<style lang="scss">
+@import '@s-sass/_variables';
+@import '@s-sass/_mixins';
+@import '@s-sass/_partials';
+
+.table-headings {
+    padding: 0 5px 0 5px;
+
+    font-size: 0.9rem;
+    font-family: $font-body;
+    text-transform: uppercase;
+
+    flex: initial;
+    display: flex;
+
+    &__mapplace {
+        min-width: 3rem;
+        flex: 1.5;
+        margin-right: 15px;
+
+        display: flex;
+    }
+
+    &__userplace {
+        min-width: 3rem;
+        flex: 4;
+        margin-right: 15px;
+
+        display: flex;
+    }
+
+    &__map {
+        display: inline;
+        flex: 6;
+
+        @include breakpoint(tablet) {
+            display: none;
+        }
+    }
+
+    &__title {
+        display: none;
+
+        @include breakpoint(tablet) {
+            display: inline;
+            flex: 6;
+        }
+    }
+
+    &__artist {
+        display: none;
+
+        @include breakpoint(tablet) {
+            display: inline;
+            flex: 4;
+        }
+    }
+
+    &__host {
+        display: none;
+
+        @include breakpoint(tablet) {
+            display: inline;
+            flex: 2.25;
+        }
+    }
+
+    &__user {
+        flex: 6;
+        
+        @include breakpoint(tablet) {
+            flex: 10.25;
+        }
+    }
+
+    &__firsts {
+        display: none;
+
+        @include breakpoint(tablet) {
+            min-width: 3rem;
+            flex: 1.5;
+
+            display: flex;
+            justify-content: center;
+        }
+    }
+
+    &__votes {
+        flex: 1.5;
+
+        display: flex;
+        justify-content: center;
+    }
+
+    &__vote-right {
+        flex: 0.5;
+        margin-right: 65px;
+    }
+}
+</style>

--- a/MCA/components/results/ResultsTableHeadings.vue
+++ b/MCA/components/results/ResultsTableHeadings.vue
@@ -1,35 +1,36 @@
-<template>    
-    <span 
-        v-if="section === 'beatmaps'"
-        class="table-headings"
-    >
-        <span class="table-headings__mapplace">{{ $t('mca.results.place') }}</span>
-        <span class="table-headings__map">{{ $t('mca.results.map') }}</span>
-        <span class="table-headings__title">{{ $t('mca.results.title') }}</span>
-        <span class="table-headings__artist">{{ $t('mca.results.artist') }}</span>
-        <span class="table-headings__host">{{ $t('mca.results.host') }}</span>
-        <span class="table-headings__firsts">{{ $t('mca.results.firsts') }}</span>
-        <span class="table-headings__votes">{{ $t('mca.results.votes') }}</span>
-        <span class="table-headings__vote-right" />
-    </span>
-    <span
-        v-else
-        class="table-headings"
-    >
-        <span class="table-headings__userplace">{{ $t('mca.results.place') }}</span>
-        <span class="table-headings__user">{{ $t('mca.results.user') }}</span>
-        <span class="table-headings__firsts">{{ $t('mca.results.firsts') }}</span>
-        <span class="table-headings__votes">{{ $t('mca.results.votes') }}</span>
-        <span class="table-headings__vote-right" />
+<template>
+    <span class="table-headings">
+        <span
+            v-for="(col, i) in filtCol"
+            :key="i"
+            :class="((col.name) ? `heading-${col.name}` : `heading-${col.label}`) +
+                    ((col.centred) ? ' heading-centred' : '') + 
+                    ((col.prio) ? ' heading-prio' : '')"
+            :style="{'flex': `${mobile && col.msize ? col.msize : col.size}`}"
+        >
+            {{ (col.label) ? $t(`mca.results.${col.label}`) : '' }}
+        </span>
     </span>
 </template>
 
 <script lang="ts">
 import { Vue, Prop, Component } from "vue-property-decorator";
+import { ResultColumn } from "../../../Interfaces/result";
 
 @Component({})
 export default class ResultsFilters extends Vue {
     @Prop({ type: String, default: ""}) readonly section!: string;
+    @Prop({ type: Array, required: true}) readonly columns!: ResultColumn[];
+    @Prop({ type: Boolean, default: false }) readonly mobile!: boolean;
+    
+    get filtCol() {
+        return this.columns.filter(
+            c => (!c.category || c.category === this.section) &&
+            ((c.mobileOnly && this.mobile) || 
+             (c.desktopOnly && !this.mobile) ||
+             (!c.mobileOnly && !c.desktopOnly))
+        );
+    }
 }
 </script>
 
@@ -48,88 +49,23 @@ export default class ResultsFilters extends Vue {
     flex: initial;
     display: flex;
 
-    &__mapplace {
-        min-width: 3rem;
-        flex: 1.5;
+    >:first-child {
         margin-right: 15px;
-
-        display: flex;
     }
 
-    &__userplace {
-        min-width: 3rem;
-        flex: 4;
-        margin-right: 15px;
-
-        display: flex;
+    >:last-child {
+        margin-right: 68px;
     }
+}
 
-    &__map {
-        display: inline;
-        flex: 6;
-
-        @include breakpoint(tablet) {
-            display: none;
-        }
-    }
-
-    &__title {
-        display: none;
-
-        @include breakpoint(tablet) {
-            display: inline;
-            flex: 6;
-        }
-    }
-
-    &__artist {
-        display: none;
-
-        @include breakpoint(tablet) {
-            display: inline;
-            flex: 4;
-        }
-    }
-
-    &__host {
-        display: none;
-
-        @include breakpoint(tablet) {
-            display: inline;
-            flex: 2.25;
-        }
-    }
-
-    &__user {
-        flex: 6;
-        
-        @include breakpoint(tablet) {
-            flex: 10.25;
-        }
-    }
-
-    &__firsts {
-        display: none;
-
-        @include breakpoint(tablet) {
-            min-width: 3rem;
-            flex: 1.5;
-
-            display: flex;
-            justify-content: center;
-        }
-    }
-
-    &__votes {
-        flex: 1.5;
-
+.heading {
+    &-centred {
         display: flex;
         justify-content: center;
     }
 
-    &__vote-right {
-        flex: 0.5;
-        margin-right: 65px;
+    &-prio {
+        min-width: 3rem;
     }
 }
 </style>

--- a/MCA/components/results/ResultsTableHeadings.vue
+++ b/MCA/components/results/ResultsTableHeadings.vue
@@ -8,7 +8,7 @@
                     ((col.prio) ? ' heading-prio' : '')"
             :style="{'flex': `${mobile && col.msize ? col.msize : col.size}`}"
         >
-            {{ (col.label) ? $t(`mca.results.${col.label}`) : '' }}
+            {{ (col.label) ? $t(`mca.results.headings.${col.label}`) : '' }}
         </span>
     </span>
 </template>

--- a/MCA/components/results/ResultsTableHeadings.vue
+++ b/MCA/components/results/ResultsTableHeadings.vue
@@ -48,12 +48,13 @@ export default class ResultsFilters extends Vue {
 
     flex: initial;
     display: flex;
+    align-items: center;
 
-    >:first-child {
+    > :first-child {
         margin-right: 15px;
     }
 
-    >:last-child {
+    > :last-child {
         margin-right: 68px;
     }
 }

--- a/MCA/components/results/ResultsUserCard.vue
+++ b/MCA/components/results/ResultsUserCard.vue
@@ -10,11 +10,16 @@
                     class="user-info__avatar"
                     :style="userAva"
                 />
-                <span class="user-info__place">{{ choice.placement }}</span>
-                <span class="user-info__username">{{ choice.username }}</span>
-                <span class="user-info__firsts">{{ choice.firstChoice }}</span>
-                <span class="user-info__votes">{{ choice.votes }}</span>
-                <span class="user-info__vote-right" />
+                <span
+                    v-for="(col, i) in filtCol"
+                    :key="i"
+                    :class="((col.name) ? `user-info__${col.name}` : `user-info__${col.label}`) +
+                            ((col.centred) ? ' user-info__centred' : '') + 
+                            ((col.prio) ? ' user-info__prio' : '')"
+                    :style="{'flex': `${mobile && col.msize ? col.msize : col.size}`}"
+                >
+                    {{ col.label ? choice[col.label] : "" }}
+                </span>
             </a>
         </div>
     </div>
@@ -22,11 +27,23 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from "vue-property-decorator";
-import { UserResult } from "../../../Interfaces/result";
+import { UserResult, ResultColumn } from "../../../Interfaces/result";
 
 @Component
 export default class ResultsUserCard extends Vue {
     @Prop({ type: Object, default: () => ({}) }) readonly choice!: UserResult;
+    @Prop({ type: Array, required: false }) columns!: ResultColumn[];
+    @Prop({ type: Boolean, default: false }) readonly mobile!: boolean;
+
+    // filter columns prop by breakpoint and category
+    get filtCol() {
+        return this.columns.filter(
+            c => (!c.category || c.category === "users") &&
+            ((c.mobileOnly && this.mobile) || 
+             (c.desktopOnly && !this.mobile) ||
+             (!c.mobileOnly && !c.desktopOnly))
+        );
+    }
 
     get userAva (): any {
         if (this.choice)
@@ -68,6 +85,7 @@ export default class ResultsUserCard extends Vue {
     position: relative;
 
     display: flex;
+    align-content: center;
 
     padding: 0 15px;
     border-radius: 10px;
@@ -75,12 +93,18 @@ export default class ResultsUserCard extends Vue {
 
     background-repeat: no-repeat;
 
-    overflow: hidden;
-
     color: white;
+    text-shadow: 0 0 4px rgba(255,255,255,0.6);
+    font-size: $font-lg;
     text-decoration: none;
 
+    @extend %text-wrap;
+
     & > span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        
         margin: 15px 0;
     }
 
@@ -102,57 +126,17 @@ export default class ResultsUserCard extends Vue {
         }
     }
 
-    &__place {
-        min-width: 3rem;
-        flex: 4;
-        text-shadow: 0 0 4px white;
-        font-size: $font-lg;
-        @extend %text-wrap;
-    }
-
     &__username {
-        flex: 6;
-        text-shadow: 0 0 4px rgba(255,255,255,0.6);
-        font-size: $font-lg;
-        @extend %text-wrap;
-
-        @include breakpoint(tablet) {
-            flex: 10.25;
-        }
+        font-weight: 500;
     }
 
-    &__firsts {
-        display: none;
-        @extend %text-wrap;
-
-        @include breakpoint(tablet) {
-            min-width: 3rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-
-            text-shadow: 0 0 4px white;
-            font-size: $font-lg;
-            
-            flex: 1.5;
-        }
-    }
-
-    &__votes {
-        min-width: 3rem;
+    &__centred {
         display: flex;
-        align-content: center;
         justify-content: center;
-
-        text-shadow: 0 0 4px white;
-        font-size: $font-lg;
-
-        flex: 1.5;
-        @extend %text-wrap;
     }
 
-    &__vote-right {
-        flex: 0.5;
+    &__prio {
+        min-width: 3rem;
     }
 }
 </style>

--- a/MCA/components/results/ResultsUserCard.vue
+++ b/MCA/components/results/ResultsUserCard.vue
@@ -11,7 +11,7 @@
                     :style="userAva"
                 />
                 <span
-                    v-for="(col, i) in filtCol"
+                    v-for="(col, i) in columns"
                     :key="i"
                     :class="((col.name) ? `user-info__${col.name}` : `user-info__${col.label}`) +
                             ((col.centred) ? ' user-info__centred' : '') + 
@@ -34,16 +34,6 @@ export default class ResultsUserCard extends Vue {
     @Prop({ type: Object, default: () => ({}) }) readonly choice!: UserResult;
     @Prop({ type: Array, required: false }) columns!: ResultColumn[];
     @Prop({ type: Boolean, default: false }) readonly mobile!: boolean;
-
-    // filter columns prop by breakpoint and category
-    get filtCol() {
-        return this.columns.filter(
-            c => (!c.category || c.category === "users") &&
-            ((c.mobileOnly && this.mobile) || 
-             (c.desktopOnly && !this.mobile) ||
-             (!c.mobileOnly && !c.desktopOnly))
-        );
-    }
 
     get userAva (): any {
         if (this.choice)

--- a/MCA/components/results/ResultsUserCard.vue
+++ b/MCA/components/results/ResultsUserCard.vue
@@ -13,9 +13,11 @@
                 <span
                     v-for="(col, i) in columns"
                     :key="i"
-                    :class="((col.name) ? `user-info__${col.name}` : `user-info__${col.label}`) +
-                            ((col.centred) ? ' user-info__centred' : '') + 
-                            ((col.prio) ? ' user-info__prio' : '')"
+                    :class="[
+                        col.name ? `user-info__${col.name}` : `user-info__${col.label}`,
+                        { 'user-info__centred': col.centred }, 
+                        { 'user-info__prio': col.prio }
+                    ]"
                     :style="{'flex': `${mobile && col.msize ? col.msize : col.size}`}"
                 >
                     {{ col.label ? choice[col.label] : "" }}

--- a/MCA/components/results/ResultsUserCard.vue
+++ b/MCA/components/results/ResultsUserCard.vue
@@ -12,6 +12,7 @@
                 />
                 <span class="user-info__place">{{ choice.placement }}</span>
                 <span class="user-info__username">{{ choice.username }}</span>
+                <span class="user-info__firsts">{{ choice.firstChoice }}</span>
                 <span class="user-info__votes">{{ choice.votes }}</span>
                 <span class="user-info__vote-right" />
             </a>
@@ -21,10 +22,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from "vue-property-decorator";
+import { UserResult } from "../../../Interfaces/result";
 
 @Component
 export default class ResultsUserCard extends Vue {
-    @Prop({ type: Object, default: () => ({}) }) readonly choice!: Record<string, any>;
+    @Prop({ type: Object, default: () => ({}) }) readonly choice!: UserResult;
 
     get userAva (): any {
         if (this.choice)
@@ -115,7 +117,24 @@ export default class ResultsUserCard extends Vue {
         @extend %text-wrap;
 
         @include breakpoint(tablet) {
-            flex: 12;
+            flex: 10.25;
+        }
+    }
+
+    &__firsts {
+        display: none;
+        @extend %text-wrap;
+
+        @include breakpoint(tablet) {
+            min-width: 3rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            text-shadow: 0 0 4px white;
+            font-size: $font-lg;
+            
+            flex: 1.5;
         }
     }
 

--- a/MCA/components/stage/StagePageList.vue
+++ b/MCA/components/stage/StagePageList.vue
@@ -29,8 +29,10 @@
                         <results-user-card
                             v-for="(item, i) in userResults"
                             :key="i"
+                            :columns="columns"
                             :choice="item"
                             :class="`results-display__user`"
+                            :mobile="mobile"
                         />
                     </template>
 
@@ -38,8 +40,10 @@
                         <results-beatmapset-card
                             v-for="(item, i) in beatmapResults"
                             :key="i"
+                            :columns="columns"
                             :choice="item"
                             :class="`results-display__beatmap`"
+                            :mobile="mobile"
                         />
                     </template>
                 </template>
@@ -73,7 +77,7 @@ import VotingBox from "./VotingBox.vue";
 import { SectionCategory } from "../../../MCA-AYIM/store/stage";
 import { UserChoiceInfo } from "../../../Interfaces/user";
 import { BeatmapsetInfo } from "../../../Interfaces/beatmap";
-import { BeatmapResult, UserResult } from "../../../Interfaces/result";
+import { BeatmapResult, UserResult, ResultColumn } from "../../../Interfaces/result";
 
 const stageModule = namespace("stage");
 
@@ -104,6 +108,8 @@ export default class StagePageList extends Vue {
     @stageModule.Action search;
 
     @Prop({ type: Boolean, default: false }) results!: boolean;
+    @Prop({ type: Array, required: false }) columns!: ResultColumn[];
+    @Prop({ type: Boolean, default: false }) readonly mobile!: boolean;
 
 }
 </script>

--- a/MCA/pages/_year/results.vue
+++ b/MCA/pages/_year/results.vue
@@ -1,25 +1,34 @@
 <template>
-    <div class="results-wrapper">
-        <mode-switcher
-            hidePhase
-            :title="$t(`mca.main.results`)"
-        >
-            <div class="results-general"> 
-                <results-filters />
-                <results-table-headings 
-                    :section="section"
-                    :columns="filtCol"
-                    :mobile="mobile"
-                />
-                <hr class="table-border">
-                <stage-page-list 
-                    results
-                    class="results-table"
-                    :columns="filtCol"
-                    :mobile="mobile"
-                />
-            </div>
-        </mode-switcher>
+    <div>
+        <div class="results-wrapper">
+            <mode-switcher
+                hidePhase
+                :title="$t(`mca.main.results`)"
+            >
+                <div class="results-general"> 
+                    <results-filters />
+                    <results-table-headings 
+                        :section="section"
+                        :columns="filtCol"
+                        :mobile="mobile"
+                    />
+                    <hr class="table-border">
+                    <stage-page-list 
+                        results
+                        class="results-table"
+                        :columns="filtCol"
+                        :mobile="mobile"
+                    />
+                </div>
+            </mode-switcher>
+        </div>
+
+        <notice-modal
+            v-if="phase && phase.phase === 'results'"
+            :title="$t('mca.main.results')"
+            :text="$t('mca.results.resultsOverlay')"
+            :localKey="'results'"
+        />
     </div>
 </template>
 
@@ -29,6 +38,7 @@ import { Getter, Mutation, State, namespace } from "vuex-class";
 import { vueWindowSizeMixin } from 'vue-window-size';
 
 import ModeSwitcher from "../../../MCA-AYIM/components/ModeSwitcher.vue";
+import NoticeModal from "../../../MCA-AYIM/components/NoticeModal.vue"
 import ResultsFilters from "../../components/results/ResultsFilters.vue";
 import ResultsTableHeadings from "../../components/results/ResultsTableHeadings.vue";
 import StagePageList from "../../components/stage/StagePageList.vue";
@@ -42,6 +52,7 @@ const stageModule = namespace("stage");
 @Component({
     components: {
         ModeSwitcher,
+        NoticeModal,
         ResultsFilters,
         ResultsTableHeadings,
         StagePageList

--- a/MCA/pages/_year/results.vue
+++ b/MCA/pages/_year/results.vue
@@ -6,32 +6,10 @@
         >
             <div class="results-general"> 
                 <results-filters />
-
-                <span 
-                    v-if="section === 'beatmaps'"
-                    class="table-headings"
-                >
-                    <span class="table-headings__mapplace">{{ $t('mca.results.place') }}</span>
-                    <span class="table-headings__map">{{ $t('mca.results.map') }}</span>
-                    <span class="table-headings__title">{{ $t('mca.results.title') }}</span>
-                    <span class="table-headings__artist">{{ $t('mca.results.artist') }}</span>
-                    <span class="table-headings__host">{{ $t('mca.results.host') }}</span>
-                    <span class="table-headings__votes">{{ $t('mca.results.votes') }}</span>
-                    <span class="table-headings__vote-right" />
-                </span>
-                
-                <span
-                    v-else
-                    class="table-headings"
-                >
-                    <span class="table-headings__userplace">{{ $t('mca.results.place') }}</span>
-                    <span class="table-headings__user">{{ $t('mca.results.user') }}</span>
-                    <span class="table-headings__votes">{{ $t('mca.results.votes') }}</span>
-                    <span class="table-headings__vote-right" />
-                </span>
-
+                <results-table-headings 
+                    :section="section"
+                />
                 <hr class="table-border">
-                
                 <stage-page-list 
                     results
                     class="results-table"
@@ -47,6 +25,7 @@ import { Getter, Mutation, State, namespace } from "vuex-class";
 
 import ModeSwitcher from "../../../MCA-AYIM/components/ModeSwitcher.vue";
 import ResultsFilters from "../../components/results/ResultsFilters.vue";
+import ResultsTableHeadings from "../../components/results/ResultsTableHeadings.vue";
 import StagePageList from "../../components/stage/StagePageList.vue";
 
 import { MCAInfo, Phase } from "../../../Interfaces/mca";
@@ -58,6 +37,7 @@ const stageModule = namespace("stage");
     components: {
         ModeSwitcher,
         ResultsFilters,
+        ResultsTableHeadings,
         StagePageList
     },
     head () {
@@ -119,85 +99,6 @@ export default class Results extends Vue {
     display: flex;
     flex-direction: column;
     overflow: hidden;
-}
-
-.table-headings {
-    padding: 0 5px 0 5px;
-
-    font-size: 0.9rem;
-    font-family: $font-body;
-    text-transform: uppercase;
-
-    flex: initial;
-    display: flex;
-
-    &__mapplace {
-        min-width: 3rem;
-        flex: 2;
-        margin-right: 15px;
-    }
-
-    &__userplace {
-        min-width: 3rem;
-        flex: 4;
-        margin-right: 15px;
-    }
-
-    &__map {
-        display: inline;
-        flex: 11;
-
-        @include breakpoint(tablet) {
-            display: none;
-        }
-    }
-
-    &__title {
-        display: none;
-
-        @include breakpoint(tablet) {
-            display: inline;
-            flex: 6;
-        }
-    }
-
-    &__artist {
-        display: none;
-
-        @include breakpoint(tablet) {
-            display: inline;
-            flex: 4;
-        }
-    }
-
-    &__host {
-        display: none;
-
-        @include breakpoint(tablet) {
-            display: inline;
-            flex: 4;
-        }
-    }
-
-    &__user {
-        flex: 6;
-        
-        @include breakpoint(tablet) {
-            flex: 12;
-        }
-    }
-
-    &__votes {
-        flex: 1.5;
-
-        display: flex;
-        justify-content: center;
-    }
-
-    &__vote-right {
-        flex: 0.5;
-        margin-right: 65px;
-    }
 }
 
 .table-border {

--- a/MCA/pages/_year/results.vue
+++ b/MCA/pages/_year/results.vue
@@ -8,11 +8,15 @@
                 <results-filters />
                 <results-table-headings 
                     :section="section"
+                    :columns="columns"
+                    :mobile="mobile"
                 />
                 <hr class="table-border">
                 <stage-page-list 
                     results
                     class="results-table"
+                    :columns="columns"
+                    :mobile="mobile"
                 />
             </div>
         </mode-switcher>
@@ -22,6 +26,7 @@
 <script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
 import { Getter, Mutation, State, namespace } from "vuex-class";
+import { vueWindowSizeMixin } from 'vue-window-size';
 
 import ModeSwitcher from "../../../MCA-AYIM/components/ModeSwitcher.vue";
 import ResultsFilters from "../../components/results/ResultsFilters.vue";
@@ -30,6 +35,7 @@ import StagePageList from "../../components/stage/StagePageList.vue";
 
 import { MCAInfo, Phase } from "../../../Interfaces/mca";
 import { SectionCategory, StageType } from "../../../MCA-AYIM/store/stage";
+import { ResultColumn } from "../../../Interfaces/result";
 
 const stageModule = namespace("stage");
 
@@ -46,6 +52,7 @@ const stageModule = namespace("stage");
         };
     }
 })
+
 export default class Results extends Vue {
     @State allMCA!: MCAInfo[];
 
@@ -62,6 +69,25 @@ export default class Results extends Vue {
     @stageModule.Action updateSection;
     @stageModule.Action updateStage;
     @stageModule.Action setInitialData;
+
+    // label must match a field in BOTH assets/lang/{lang}/mca.results.*
+    //   AND a property of either BeatmapResults or UserResults 
+    columns: ResultColumn[] = [
+        {label: "placement", size: 1.5, category: "beatmaps", prio: true}, 
+        {label: "placement", size: 4, category: "users", prio: true},
+        {label: "map", size: 6, category: "beatmaps", mobileOnly: true},
+        {label: "title", size: 6, category: "beatmaps", desktopOnly: true},
+        {label: "artist", size: 4, category: "beatmaps", desktopOnly: true},
+        {label: "hoster", size: 2.25, category: "beatmaps", desktopOnly: true},
+        {label: "username", size: 10.25, msize: 6, category: "users"},
+        {label: "firstChoice", size: 1.5, desktopOnly: true, centred: true},
+        {label: "totalVotes", size: 1.5, centred: true, prio: true},
+        {name: "vr", size: 0.5},
+    ]
+
+    get mobile(): Boolean {
+        return vueWindowSizeMixin.computed.windowWidth() < 768;
+    }
 
     mounted () {
         if (!(this.phase?.phase === 'results' || this.isMCAStaff)) {

--- a/MCA/pages/_year/results.vue
+++ b/MCA/pages/_year/results.vue
@@ -8,14 +8,14 @@
                 <results-filters />
                 <results-table-headings 
                     :section="section"
-                    :columns="columns"
+                    :columns="filtCol"
                     :mobile="mobile"
                 />
                 <hr class="table-border">
                 <stage-page-list 
                     results
                     class="results-table"
-                    :columns="columns"
+                    :columns="filtCol"
                     :mobile="mobile"
                 />
             </div>
@@ -84,6 +84,16 @@ export default class Results extends Vue {
         {label: "totalVotes", size: 1.5, centred: true, prio: true},
         {name: "vr", size: 0.5},
     ]
+
+    // filter columns by breakpoint and category
+    get filtCol() {
+        return this.columns.filter(
+            c => (!c.category || c.category === this.section) &&
+            ((c.mobileOnly && this.mobile) || 
+             (c.desktopOnly && !this.mobile) ||
+             (!c.mobileOnly && !c.desktopOnly))
+        );
+    }
 
     get mobile(): Boolean {
         return vueWindowSizeMixin.computed.windowWidth() < 768;

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,8 @@
             "nodemon": "^2.0.7",
             "nodesu": "https://github.com/ThePooN/nodesu/archive/502d65b9f84dd2fbe0a24f4eeaf9359305f8bcc3.tar.gz",
             "sass": "^1.32.2",
-            "sass-loader": "^10.1.0"
+            "sass-loader": "^10.1.0",
+            "vue-window-size": "^0.6.2"
          }
       },
       "node_modules/@babel/code-frame": {
@@ -16464,6 +16465,18 @@
          "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
          "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
       },
+      "node_modules/vue-window-size": {
+         "version": "0.6.2",
+         "resolved": "https://registry.npmjs.org/vue-window-size/-/vue-window-size-0.6.2.tgz",
+         "integrity": "sha512-/mODjnC5xdZb0T0UlnUzYgOgxeaUVCEuBZkiD4jss2LkByA+208SA+MhMKvZFcMvej484+7mDjr2q9TNIRj+Dw==",
+         "dev": true,
+         "dependencies": {
+            "window-resize-subject": "^1.4.2"
+         },
+         "peerDependencies": {
+            "vue": ">=2.6"
+         }
+      },
       "node_modules/vuex": {
          "version": "3.6.0",
          "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.0.tgz",
@@ -17086,6 +17099,12 @@
          "engines": {
             "node": ">=8"
          }
+      },
+      "node_modules/window-resize-subject": {
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/window-resize-subject/-/window-resize-subject-1.5.0.tgz",
+         "integrity": "sha512-r+zXdtumr1+De51Lb3P561K+3t6PvEVXq+dTaEhikNY8Hj0UuzkYL3v9jo5TLpPaL7s9gkaX3Sb643HqYT7uSA==",
+         "dev": true
       },
       "node_modules/word-wrap": {
          "version": "1.2.3",
@@ -31281,6 +31300,15 @@
          "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
          "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
       },
+      "vue-window-size": {
+         "version": "0.6.2",
+         "resolved": "https://registry.npmjs.org/vue-window-size/-/vue-window-size-0.6.2.tgz",
+         "integrity": "sha512-/mODjnC5xdZb0T0UlnUzYgOgxeaUVCEuBZkiD4jss2LkByA+208SA+MhMKvZFcMvej484+7mDjr2q9TNIRj+Dw==",
+         "dev": true,
+         "requires": {
+            "window-resize-subject": "^1.4.2"
+         }
+      },
       "vuex": {
          "version": "3.6.0",
          "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.0.tgz",
@@ -31798,6 +31826,12 @@
                }
             }
          }
+      },
+      "window-resize-subject": {
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/window-resize-subject/-/window-resize-subject-1.5.0.tgz",
+         "integrity": "sha512-r+zXdtumr1+De51Lb3P561K+3t6PvEVXq+dTaEhikNY8Hj0UuzkYL3v9jo5TLpPaL7s9gkaX3Sb643HqYT7uSA==",
+         "dev": true
       },
       "word-wrap": {
          "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
       "nodemon": "^2.0.7",
       "nodesu": "https://github.com/ThePooN/nodesu/archive/502d65b9f84dd2fbe0a24f4eeaf9359305f8bcc3.tar.gz",
       "sass": "^1.32.2",
-      "sass-loader": "^10.1.0"
+      "sass-loader": "^10.1.0",
+      "vue-window-size": "^0.6.2"
    },
    "scripts": {
       "build:ayim": "cd ./AYIM && nuxt-ts build",


### PR DESCRIPTION
might need to change name in lang files if it's unclear but i think the brevity is preferred
could also test a popup on first visit to results page a la voting page that explains how the results work

in addition i made all the css for the results table be based off an array of type ResultsColumn stored in results.vue's state while also having the heading/cards be dynamically rendered instead
should make adding/rearranging columns be a LOT easier in the future

other than that cleaned up css and added some comments where necessary