### PR TITLE
Fix click-to-scroll requiring regular scroll before enabling

### DIFF
--- a/MCA-AYIM/components/ScrollBar.vue
+++ b/MCA-AYIM/components/ScrollBar.vue
@@ -62,7 +62,7 @@ export default class ScrollBar extends Vue {
             const newScrollPos = event.offsetY / this.$el.clientHeight * this.scrollSize;
             this.scrollPos = newScrollPos;   
             
-            list.scrollTo({top: newScrollPos });
+            list.scrollTo({ top: newScrollPos });
         }
     }
 

--- a/MCA-AYIM/components/ScrollBar.vue
+++ b/MCA-AYIM/components/ScrollBar.vue
@@ -31,7 +31,6 @@ export default class ScrollBar extends Vue {
 
         if (list) {
             list.addEventListener("scroll", this.handleScroll);
-            this.scrollSize = list.scrollHeight - list.clientHeight;
         }
 
         if (scrollTrack) {
@@ -57,14 +56,13 @@ export default class ScrollBar extends Vue {
     }
 
     handleJump (event) {
-        if (event.target) {
+        const list = document.querySelector(this.selector);
+        if (event.target && list) {
+            this.scrollSize = list.scrollHeight - list.clientHeight;
             const newScrollPos = event.offsetY / this.$el.clientHeight * this.scrollSize;
-            const list = document.querySelector(this.selector);
             this.scrollPos = newScrollPos;   
             
-            if (list) {
-                list.scrollTo({top: newScrollPos });
-            }
+            list.scrollTo({top: newScrollPos });
         }
     }
 


### PR DESCRIPTION
reason why this was happening was cuz this.scrollSize wasn't being set to the correct value initially.
it got set initially (on mount) when the container to be scrolled isnt populated yet, yielding a scrollSize of 0.
removed this initial assignment and added it to handleJump().
it was already in handleScroll() which is why that was working.