### PR TITLE
Fix standard nominations that had only 1 nomination showing up in categories

### DIFF
--- a/Models/beatmap.ts
+++ b/Models/beatmap.ts
@@ -137,7 +137,9 @@ export class Beatmap extends BaseEntity {
                         .select("count(nominator.ID)")
                         .from(Nomination, "nomination")
                         .innerJoin("nomination.nominators", "nominator")
+                        .leftJoin("nomination.category", "category")
                         .where("nomination.beatmap = beatmap.ID")
+                        .andWhere("category.ID = :categoryId", { categoryId: category.ID })
                         .getQuery();
 
                     return `${subQuery} >= 2`;

--- a/Models/beatmapset.ts
+++ b/Models/beatmapset.ts
@@ -100,7 +100,9 @@ export class Beatmapset extends BaseEntity {
                         .select("count(nominator.ID)")
                         .from(Nomination, "nomination")
                         .innerJoin("nomination.nominators", "nominator")
+                        .leftJoin("nomination.category", "category")
                         .where("nomination.beatmapset = beatmapset.ID")
+                        .andWhere("category.ID = :categoryId", { categoryId: category.ID })
                         .getQuery();
 
                     return `${subQuery} >= 2`;

--- a/Models/user.ts
+++ b/Models/user.ts
@@ -207,7 +207,9 @@ export class User extends BaseEntity {
                         .select("count(nominator.ID)")
                         .from(Nomination, "nomination")
                         .innerJoin("nomination.nominators", "nominator")
+                        .leftJoin("nomination.category", "category")
                         .where("nomination.user = user.ID")
+                        .andWhere("category.ID = :categoryId", { categoryId: category.ID })
                         .getQuery();
 
                     return `${subQuery} >= 2`;


### PR DESCRIPTION
For standard, there needs to be at least 2 nominations in that specific category for a beatmap/user to pass voting stage for that specific category.

Currently, this could be bypassed by a beatmap/user being nominated in more than 1 category, which would cause it to show up in both categories in the voting stage even if only 1 user nominated it in a specific category.

(For ex. 1 user nominated a map in marathon, 1 user nominated a map in collab, now it shows up in both marathon and collab even though it shouldn't show up in either)

This fixes that