### PR TITLE
Promisify Download to Catch HTTP Errors

### DIFF
--- a/DiscordBot/commands/tournaments/mappool/download.ts
+++ b/DiscordBot/commands/tournaments/mappool/download.ts
@@ -42,7 +42,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
         return;
     }
 
-    const components = await mappoolComponents(m, pool, slot, order ?? (slot ? true : undefined));
+    const components = await mappoolComponents(m, pool, slot || true, order || true);
     if (!components || !("mappool" in components))
         return;
 
@@ -79,6 +79,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
                 },
             ]);
         } catch (e) {
+            console.log(e);
             await respond(m, `Can't download **${pool}**\nosu.direct is proly currently down. Error below:\n\`\`\`\n${e}\`\`\``);
         }
 
@@ -114,6 +115,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
         mappool.mappackLink = url;
         mappool.mappackExpiry = new Date(Date.now() + 60 * 60 * 24 * 1000);
     } catch (e) {
+        console.log(e);
         await respond(m, `Can't download **${pool}**\nosu.direct is proly currently down. Error below:\n\`\`\`\n${e}\`\`\``);
         return;
     }

--- a/DiscordBot/functions/tournamentFunctions/mappackFunctions.ts
+++ b/DiscordBot/functions/tournamentFunctions/mappackFunctions.ts
@@ -12,6 +12,8 @@ import { Beatmap as APIBeatmap } from "nodesu";
 import respond from "../respond";
 
 export async function createPack (m: Message | ChatInputCommandInteraction, bucket: "mappacks" | "mappacksTemp", mappool: Mappool, packName: string, video = false): Promise<string | undefined> {
+    const loadingMsg = await m.channel?.send("Getting maps...");
+
     const mappoolMaps = mappool.slots.flatMap(s => s.maps);
     const filteredMaps = mappoolMaps.filter(m => (m.customBeatmap && m.customBeatmap.link) || m.beatmap);
     if (filteredMaps.length === 0) {
@@ -39,11 +41,13 @@ export async function createPack (m: Message | ChatInputCommandInteraction, buck
     const names = updatedMaps.map(m => m.beatmap ? `${m.beatmap.beatmapset.ID} ${m.beatmap.beatmapset.artist} - ${m.beatmap.beatmapset.title}.osz` : `${m.customBeatmap!.ID} ${m.customBeatmap!.artist} - ${m.customBeatmap!.title}.osz`);
     const dlLinks = updatedMaps.map(m => m.customBeatmap ? m.customBeatmap.link! : `https://osu.direct/api/d/${m.beatmap!.beatmapsetID}${video ? "" : "n"}`);
 
-    const streams = dlLinks.map(link => download(link));
+    await loadingMsg?.edit("Downloading maps...");
+    const streams = await Promise.all(dlLinks.map(link => download(link)));
     const zipStream = zipFiles(streams.map((d, i) => ({ content: d, name: names[i] })));
 
     const s3Key = `${randomUUID()}/${packName}.zip`;
 
+    await loadingMsg?.edit("Uploading pack...");
     try {
         if (bucket === "mappacksTemp") {
             await buckets.mappacksTemp.putObject(s3Key, zipStream, "application/zip");
@@ -53,9 +57,13 @@ export async function createPack (m: Message | ChatInputCommandInteraction, buck
 
         await buckets.mappacks.putObject(s3Key, zipStream, "application/zip");
         const url = await buckets.mappacks.getPublicUrl(s3Key);
+        await loadingMsg?.delete();
         return url;
     } catch (e) {
-        await respond(m, "Failed to create pack. Contact VINXIS");
+        await Promise.all([
+            loadingMsg?.delete(),
+            respond(m, "Failed to create pack. Contact VINXIS"),
+        ]);
         console.log(e);
         return;
     }

--- a/Server/utils/download.ts
+++ b/Server/utils/download.ts
@@ -1,14 +1,17 @@
 import * as https from "https";
 import { PassThrough, Readable } from "stream";
 
-export function download (url: string): Readable {
-    const passThrough = new PassThrough();
-    https.get(url, (res) => {
-        if (res.statusCode && res.statusCode >= 400) {
-            passThrough.emit("error", new Error(`HTTP Error ${res.statusCode}`));
-            return;
-        }
-        res.pipe(passThrough);
+export async function download (url: string): Promise<Readable> {
+    return new Promise((resolve, reject) => {
+        const passThrough = new PassThrough();
+
+        https.get(url, (res) => {
+            if (res.statusCode && res.statusCode >= 400) {
+                reject(new Error(`HTTP Error ${res.statusCode} from ${url}`));
+                return;
+            }
+            res.pipe(passThrough);
+            resolve(passThrough);
+        });
     });
-    return passThrough;
 }


### PR DESCRIPTION
Dunno if this is fine but I noticed HTTP errors weren't being caught by try catch https://github.com/Corsace/Corsace/blob/c1d12e85ecd8f38150b3c8b913d29e94743af577/DiscordBot/commands/tournaments/mappool/download.ts#L117