### PR TITLE
Banchobot graceful shutdown

### DIFF
--- a/BanchoBot/functions/tournaments/matchup/runMatchup.ts
+++ b/BanchoBot/functions/tournaments/matchup/runMatchup.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
-import { banchoClient } from "../../..";
+import { banchoClient, maybeShutdown } from "../../..";
+import state from "../../../state";
 import { leniencyTime } from "../../../../Models/tournaments/stage";
 import { Matchup } from "../../../../Models/tournaments/matchup";
 import { StageType, ScoringMethod } from "../../../../Interfaces/stage";
@@ -49,6 +50,8 @@ function runMatchupCheck (matchup: Matchup, replace: boolean) {
 }
 
 async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpChannel: BanchoChannel) {
+    state.runningMatchups++;
+
     let autoStart = false;
     let mapsPlayed: MappoolMap[] = [];
     let mapTimerStarted = false;
@@ -81,11 +84,6 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
 
         await mpChannel.sendMessage("Matchup lobby closed due to managers not joining");
         await mpLobby.closeLobby();
-
-        matchup.mp = mpLobby.id;
-        await matchup.save();
-
-        clearInterval(messageSaver);
     }, matchup.date.getTime() - Date.now() + 15 * 60 * 1000);
 
     mpChannel.on("message", async (message) => {
@@ -311,11 +309,6 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
                     await mpChannel.sendMessage(`No more maps to play, closing lobby in ${leniencyTime / 1000} seconds`);
                     await pause(leniencyTime);
                     await mpLobby.closeLobby();
-
-                    matchup.mp = mpLobby.id;
-                    await matchup.save();
-
-                    clearInterval(messageSaver);
                     return;
                 }
                 log(matchup, `Map picked: ${mpLobby.beatmapId} with mods ${mpLobby.mods.map(m => m.shortMod).join(", ")}`);
@@ -325,6 +318,19 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
                 log(matchup, `Error loading beatmap: ${ex}`);
             }
         }, matchup.streamer ? 30 * 1000 : 0);
+    });
+
+    mpLobby.channel.on("PART", async (member) => {
+        if (member.user.isClient()) {
+            // Lobby is closed
+            matchup.mp = mpLobby.id;
+            await matchup.save();
+    
+            clearInterval(messageSaver);
+
+            state.runningMatchups--;
+            maybeShutdown();
+        }
     });
 }
 

--- a/BanchoBot/index.ts
+++ b/BanchoBot/index.ts
@@ -5,10 +5,14 @@ import { handleCommand } from "./commands";
 import baseServer from "../Server/baseServer";
 import koaBody from "koa-body";
 import Mount from "koa-mount";
+import gracefulShutdown from "http-graceful-shutdown";
 
 import banchoRouter from "../Server/api/routes/bancho";
 
 import ormConfig from "../ormconfig";
+
+import state from "./state";
+import { discordClient } from "../Server/discord";
 
 // Bancho Client
 const banchoClient = new BanchoClient({ username: config.osu.bancho.username, password: config.osu.bancho.ircPassword, botAccount: config.osu.bancho.botAccount, apiKey: config.osu.v1.apiKey });
@@ -17,10 +21,13 @@ banchoClient.connect().catch(err => {
 });
 
 banchoClient.on("connected", () => {
-    console.log(`Logged into osu! as ${banchoClient.getSelf().ircUsername}`);
+    console.log(`Logged into Bancho as ${banchoClient.getSelf().ircUsername}`);
 });
 
 banchoClient.on("PM", async (message) => {
+    if (state.shuttingDown)
+        return;
+
     // ignore messages from our own user
     if (message.self)
         return;
@@ -46,11 +53,55 @@ koa.use(koaBody());
 /// Cron
 koa.use(Mount("/api/bancho", banchoRouter.routes()));
 
+let httpShutdown: () => Promise<void> | undefined;
 ormConfig.initialize()
     .then(async (connection) => {
         console.log(`Connected to the ${connection.options.database} database!`);
-        koa.listen(config.banchoBot.port);
+        const server = koa.listen(config.banchoBot.port);
+        httpShutdown = gracefulShutdown(server, {
+            signals: "", // leave signals handling to us
+            onShutdown: async () => {
+                console.log("Done handling all API requests.");
+                maybeShutdown();
+            },
+        });
     })
     .catch((error) => console.log("An error has occurred in connecting.", error));
 
-export { banchoClient };
+const maybeShutdown = () => {
+    if (!state.shuttingDown)
+        return;
+
+    if (state.runningMatchups > 0) {
+        console.log(`Waiting for ${state.runningMatchups} matchups to finish...`);
+    } else {
+        console.log("No running matchup.");
+        ormConfig.destroy();
+        discordClient.destroy();
+        banchoClient.disconnect();
+        console.log("Disconnected from every service, shutting down now.");
+        process.exit();
+    }
+};
+
+const onTerminationSignal = (signal: NodeJS.Signals) => {
+    // HTTP server not initiated yet, simply exiting.
+    if (!httpShutdown) {
+        process.exit();
+    }
+
+    if (state.shuttingDown) {
+        console.warn(`Received ${signal}, but already shutting down. Ignoring.`);
+        return;
+    }
+    
+    state.shuttingDown = true;
+    console.log(`Received shutdown signal (${signal}), initiating shutdown sequence.`);
+    
+    httpShutdown();
+};
+
+process.on("SIGTERM", () => onTerminationSignal("SIGTERM"));
+process.on("SIGINT", () => onTerminationSignal("SIGINT"));
+
+export { banchoClient, maybeShutdown };

--- a/BanchoBot/index.ts
+++ b/BanchoBot/index.ts
@@ -61,6 +61,7 @@ ormConfig.initialize()
         httpShutdown = gracefulShutdown(server, {
             signals: "", // leave signals handling to us
             onShutdown: async () => {
+                state.httpServerShutDown = true;
                 console.log("Done handling all API requests.");
                 maybeShutdown();
             },
@@ -69,7 +70,7 @@ ormConfig.initialize()
     .catch((error) => console.log("An error has occurred in connecting.", error));
 
 const maybeShutdown = () => {
-    if (!state.shuttingDown)
+    if (!state.shuttingDown || !state.httpServerShutDown)
         return;
 
     if (state.runningMatchups > 0) {

--- a/BanchoBot/state.ts
+++ b/BanchoBot/state.ts
@@ -1,0 +1,6 @@
+const state = {
+    shuttingDown: false,
+    runningMatchups: 0,
+};
+
+export default state;

--- a/BanchoBot/state.ts
+++ b/BanchoBot/state.ts
@@ -1,5 +1,6 @@
 const state = {
     shuttingDown: false,
+    httpServerShutDown: false,
     runningMatchups: 0,
 };
 

--- a/DiscordBot/index.ts
+++ b/DiscordBot/index.ts
@@ -37,11 +37,6 @@ const rest = new REST({ version: "10" }).setToken(config.discord.token);
     }
 })();
 
-// Ready instance for the bot
-discordClient.once("ready", () => {
-    console.log(`Logged into discord as ${discordClient.user?.tag}`);
-});
-
 // Start the bot
 ormConfig.initialize()
     .then((connection) => {

--- a/Server/api/routes/bancho/index.ts
+++ b/Server/api/routes/bancho/index.ts
@@ -66,16 +66,14 @@ banchoRouter.post("/runMatchups", validateData, async (ctx) => {
         .andWhere("matchup.mp IS NULL")
         .getMany();
 
-    matchups.forEach(matchup => {
-        runMatchup(matchup).catch(err => {
-            if (err) {
-                console.log(err);
-                const channel = discordClient.channels.cache.get(config.discord.coreChannel);
-                if (channel instanceof TextChannel)
-                    channel.send(`Error running match GHIVE THIS IMMEDIATE ATTENTION:\n\`\`\`\n${err}\n\`\`\``);
-            }
+    for (const matchup of matchups) {
+        await runMatchup(matchup).catch(err => {
+            console.error(err);
+            const channel = discordClient.channels.cache.get(config.discord.coreChannel);
+            if (channel instanceof TextChannel)
+                channel.send(`Error running match GHIVE THIS IMMEDIATE ATTENTION:\n\`\`\`\n${err}\n\`\`\``);
         });
-    });
+    }
 });
 
 export default banchoRouter;

--- a/Server/discord.ts
+++ b/Server/discord.ts
@@ -20,6 +20,11 @@ discordClient.login(config.discord.token).catch(err => {
     if (err) throw err;
 });
 
+// Ready instance for the bot
+discordClient.once("ready", () => {
+    console.log(`Logged into discord as ${discordClient.user?.tag}`);
+});
+
 discordClient.on("error", err => {
     console.error(err);
 });

--- a/corsace-chart/templates/deployment-discord-bot.yaml
+++ b/corsace-chart/templates/deployment-discord-bot.yaml
@@ -35,9 +35,9 @@ spec:
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command:
-            - npm
-            - run
-            - discord-bot
+            - node
+            - dist/DiscordBot/index.js
+          workingDir: /srv/DiscordBot
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
           env:

--- a/corsace-chart/templates/deployment-webservices.yaml
+++ b/corsace-chart/templates/deployment-webservices.yaml
@@ -41,9 +41,10 @@ spec:
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command:
-            - npm
-            - run
-            - {{ $webService.command }}
+            {{- $webService.command | toYaml | nindent 12 }}
+          {{- with $webService.workingDir }}
+          workingDir: {{ . | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -60,7 +61,9 @@ spec:
             {{- toYaml $.Values.resources | nindent 12 }}
           env:
             {{- include "corsace-chart.env" $ | nindent 12 }}
-
+      {{- with $webService.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/corsace-chart/values.yaml
+++ b/corsace-chart/values.yaml
@@ -62,7 +62,11 @@ secrets:
 webServices:
   corsace:
     replicaCount: 1
-    command: main
+    command:
+      - npx
+      - nuxt
+      - start
+    workingDir: /src/Main
     publicUrl: https://corsace.io
     ssr: true
     ingress:
@@ -76,7 +80,11 @@ webServices:
             - path: /
   mca:
     replicaCount: 1
-    command: mca
+    command:
+      - npx
+      - nuxt
+      - start
+    workingDir: /src/MCA
     publicUrl: https://mca.corsace.io
     ssr: true
     ingress:
@@ -87,7 +95,11 @@ webServices:
             - path: /
   ayim:
     replicaCount: 1
-    command: ayim
+    command:
+      - npx
+      - nuxt
+      - start
+    workingDir: /src/AYIM
     publicUrl: https://ayim.corsace.io
     ssr: true
     ingress:
@@ -98,7 +110,11 @@ webServices:
             - path: /
   open:
     replicaCount: 1
-    command: open
+    command:
+      - npx
+      - nuxt
+      - start
+    workingDir: /src/Open
     publicUrl: https://open.corsace.io
     ssr: true
     ingress:
@@ -109,18 +125,28 @@ webServices:
             - path: /
   api:
     replicaCount: 1
-    command: api
+    command:
+      - node
+      - dist/Server/index.js
+    workingDir: /src/Server
     ingress:
       enabled: false
   cronRunner:
     replicaCount: 1
-    command: cron-runner
+    command:
+      - node
+      - dist/Server/cron-runner.js
+    workingDir: /src/Server
     strategyType: Recreate
     ingress:
       enabled: false
   banchoBot:
     replicaCount: 1
-    command: bancho-bot
+    command:
+      - node
+      - dist/BanchoBot/index.js
+    workingDir: /src/BanchoBot
+    terminationGracePeriodSeconds: 21600
     strategyType: Recreate
     ingress:
       enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
             "bancho.js": "^0.11.1",
             "cron": "^2.3.0",
             "discord.js": "^14.9.0",
+            "http-graceful-shutdown": "^3.1.13",
             "jimp": "^0.22.8",
             "koa": "^2.13.1",
             "koa-basic-auth": "^4.0.0",
@@ -11905,6 +11906,17 @@
          },
          "engines": {
             "node": ">= 0.6"
+         }
+      },
+      "node_modules/http-graceful-shutdown": {
+         "version": "3.1.13",
+         "resolved": "https://registry.npmjs.org/http-graceful-shutdown/-/http-graceful-shutdown-3.1.13.tgz",
+         "integrity": "sha512-Ci5LRufQ8AtrQ1U26AevS8QoMXDOhnAHCJI3eZu1com7mZGHxREmw3dNj85ftpQokQCvak8nI2pnFS8zyM1M+Q==",
+         "dependencies": {
+            "debug": "^4.3.4"
+         },
+         "engines": {
+            "node": ">=4.0.0"
          }
       },
       "node_modules/http-proxy": {
@@ -30373,6 +30385,14 @@
             "setprototypeof": "1.2.0",
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
+         }
+      },
+      "http-graceful-shutdown": {
+         "version": "3.1.13",
+         "resolved": "https://registry.npmjs.org/http-graceful-shutdown/-/http-graceful-shutdown-3.1.13.tgz",
+         "integrity": "sha512-Ci5LRufQ8AtrQ1U26AevS8QoMXDOhnAHCJI3eZu1com7mZGHxREmw3dNj85ftpQokQCvak8nI2pnFS8zyM1M+Q==",
+         "requires": {
+            "debug": "^4.3.4"
          }
       },
       "http-proxy": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       "bancho.js": "^0.11.1",
       "cron": "^2.3.0",
       "discord.js": "^14.9.0",
+      "http-graceful-shutdown": "^3.1.13",
       "jimp": "^0.22.8",
       "koa": "^2.13.1",
       "koa-basic-auth": "^4.0.0",


### PR DESCRIPTION
Add delayed shutdown to BanchoBot when matchups are running.

On deployment in production, a new BanchoBot instance is spawned, then SIGTERM is sent to the currently-running instance. The HTTP server will stop but any remaining lobby will keep running for up to 6 hours, while the new instance accepts any new match-up (effectively zero downtime).

This is similar to the production osu!lazer osu-server-spectator deployment FWIW.