### PR TITLE
Discord Fixes, and Team Changes for Short-Term Multi-Tourney Support

### DIFF
--- a/AYIM/layouts/default.vue
+++ b/AYIM/layouts/default.vue
@@ -11,7 +11,7 @@
                 :href="`/${$route.params.year}`"
                 @click="updateSelectedMode('')"
             >
-            <!-- TODO: Remove year -->
+                <!-- TODO: Remove year -->
                 <img
                     :src="require(`../../Assets/img/site/mca-ayim/year/${$route.params.year || 2023}-${viewTheme}-ayim.png`)"
                     class="mcaayim__logo"

--- a/BanchoBot/functions/tournaments/matchup/runMatchup.ts
+++ b/BanchoBot/functions/tournaments/matchup/runMatchup.ts
@@ -82,6 +82,8 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
         if (started)
             return;
 
+        matchup.mp = mpLobby.id;
+        await matchup.save();
         await mpChannel.sendMessage("Matchup lobby closed due to managers not joining");
         await mpLobby.closeLobby();
     }, matchup.date.getTime() - Date.now() + 15 * 60 * 1000);

--- a/DiscordBot/commands/tournaments/create.ts
+++ b/DiscordBot/commands/tournaments/create.ts
@@ -403,7 +403,7 @@ async function tournamentRoles (m: Message, tournament: Tournament, creator: Use
             }
             const role = await m.guild!.roles.create({
                 name: `${tournament.name} ${roleString}`,
-                reason: `Created by ${m.author.tag} for tournament ${tournament.name}`,
+                reason: `Created by ${m.author.username} for tournament ${tournament.name}`,
                 mentionable: true,
             });
             const tournamentRole = new TournamentRole();
@@ -620,7 +620,7 @@ async function tournamentChannels (m: Message, tournament: Tournament, creator: 
                 type: channelType,
                 name: `${tournament.abbreviation}-${channelTypeMenu}`,
                 topic: `Tournament ${tournament.name} channel for ${channelTypeMenu}`,
-                reason: `${tournament.name} channel created by ${m.author.tag} for ${(i as StringSelectMenuInteraction).values[0]} purposes.`,
+                reason: `${tournament.name} channel created by ${m.author.username} for ${(i as StringSelectMenuInteraction).values[0]} purposes.`,
                 defaultAutoArchiveDuration: 10080,
             };
 
@@ -840,7 +840,7 @@ async function tournamentSave (m: Message, tournament: Tournament) {
             { name: "Server", value: tournament.server, inline: true }
         )
         .setTimestamp(new Date)
-        .setAuthor({ name: m.author.tag, iconURL: m.member?.avatarURL() ?? undefined });
+        .setAuthor({ name: m.author.username, iconURL: m.member?.avatarURL() ?? undefined });
 
     if (tournament.isOpen || tournament.isClosed)
         embed.addFields(

--- a/DiscordBot/commands/tournaments/edit.ts
+++ b/DiscordBot/commands/tournaments/edit.ts
@@ -284,7 +284,7 @@ async function tournamentSave (m: Message, tournament: Tournament) {
             { name: "Server", value: tournament.server, inline: true }
         )
         .setTimestamp(new Date)
-        .setAuthor({ name: m.author.tag, iconURL: m.member?.avatarURL() ?? undefined });
+        .setAuthor({ name: m.author.username, iconURL: m.member?.avatarURL() ?? undefined });
 
     if (tournament.isOpen || tournament.isClosed)
         embed.addFields(

--- a/DiscordBot/commands/tournaments/mappool/edit.ts
+++ b/DiscordBot/commands/tournaments/mappool/edit.ts
@@ -169,7 +169,7 @@ async function mappoolSave (m: Message, mappool: Mappool, tournament: Tournament
                 };
             }))
         .setTimestamp(new Date)
-        .setAuthor({ name: commandUser(m).tag, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() || undefined });
+        .setAuthor({ name: commandUser(m).username, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() || undefined });
 
     await Promise.all([
         m.channel!.send({ embeds: [embed] }),

--- a/DiscordBot/commands/tournaments/stage/create.ts
+++ b/DiscordBot/commands/tournaments/stage/create.ts
@@ -268,7 +268,7 @@ async function stageDone (m: Message | ChatInputCommandInteraction, stage: Stage
             { name: "Initial → Final Team Count", value: stage.initialSize + " → " + stage.finalSize, inline: true }
         )
         .setTimestamp(new Date)
-        .setAuthor({ name: commandUser(m).tag, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() || undefined });
+        .setAuthor({ name: commandUser(m).username, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() || undefined });
 
     if (stage.stageType === StageType.Qualifiers)
         embed.addFields({ name: "Team Qualifier Choose Order", value: stage.qualifierTeamChooseOrder ? "Yes" : "No", inline: true });

--- a/DiscordBot/commands/tournaments/stage/edit.ts
+++ b/DiscordBot/commands/tournaments/stage/edit.ts
@@ -294,7 +294,7 @@ async function stageSave (m: Message, stage: Stage) {
             { name: "Initial → Final Team Count", value: stage.initialSize + " → " + stage.finalSize, inline: true }
         )
         .setTimestamp(new Date)
-        .setAuthor({ name: commandUser(m).tag, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() || undefined });
+        .setAuthor({ name: commandUser(m).username, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() || undefined });
 
     if (stage.stageType === StageType.Qualifiers)
         embed.addFields({ name: "Team Qualifier Choose Order", value: stage.qualifierTeamChooseOrder ? "Yes" : "No", inline: true });

--- a/DiscordBot/commands/tournaments/team/schedule.ts
+++ b/DiscordBot/commands/tournaments/team/schedule.ts
@@ -114,7 +114,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
             const users = await User
                 .createQueryBuilder("user")
                 .leftJoinAndSelect("user.otherNames", "otherName")
-                .where("user.osuUserid = :userId", { userId: target })
+                .where("user.osuUserid = :user")
                 .orWhere("user.osuUsername LIKE :user")
                 .orWhere("otherName.name LIKE :user")
                 .setParameter("user", `%${target}%`)
@@ -149,7 +149,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
         }
     } 
     
-    // Rerun for when the target is a userm or if there was no target at all
+    // Rerun for when the target is a user or if there was no target at all
     if (!team) {
         const teams = await Team
             .createQueryBuilder("team")

--- a/DiscordBot/commands/tournaments/team/schedule.ts
+++ b/DiscordBot/commands/tournaments/team/schedule.ts
@@ -22,9 +22,6 @@ import { StageType } from "../../../../Interfaces/stage";
 import { cron } from "../../../../Server/cron";
 import { CronJobType } from "../../../../Interfaces/cron";
 import { discordClient } from "../../../../Server/discord";
-import { MatchupMessage } from "../../../../Models/tournaments/matchupMessage";
-import { MatchupScore } from "../../../../Models/tournaments/matchupScore";
-import { MatchupMap } from "../../../../Models/tournaments/matchupMap";
 
 // TODO: Merge the functionality in this command with the team create and register and qualifier API endpoints
 async function singlePlayerTournamentTeamCreation (m: Message | ChatInputCommandInteraction, user: User, tournament: Tournament) {

--- a/DiscordBot/commands/tournaments/teams.ts
+++ b/DiscordBot/commands/tournaments/teams.ts
@@ -31,7 +31,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
                 return `**${team.name}** (${team.abbreviation})\n**Manager:** ${team.manager.osu.username} <@${team.manager.discord.userID}>\n**Members:** ${team.members.map(m => m.osu.username).join(", ")}`;
             }).join("\n\n"))
         .setFooter({
-            text: `Requested by ${m instanceof Message ? m.author.tag : m.user.tag}`,
+            text: `Requested by ${m instanceof Message ? m.author.username : m.user.username}`,
             iconURL: (m instanceof Message ? m.author.avatarURL() : m.user.avatarURL()) || undefined,
         });
 

--- a/DiscordBot/handlers/guildMemberAdd.ts
+++ b/DiscordBot/handlers/guildMemberAdd.ts
@@ -44,19 +44,25 @@ export default async function guildMemberAdd (member: GuildMember) {
         });
         if (user)
             roles.push(config.discord.roles.corsace.verified);
-        else
-            member.send("Hello and welcome to Corsace.\n\nIf u wanna type in the discord server, make sure u log in on osu! and then discord at https://corsace.io to obtain the `Verified` role. That will give u typing abilities");
+        else {
+            try {
+                member.send("Hello and welcome to Corsace.\n\nIf u wanna type in the discord server, make sure u log in on osu! and then discord at https://corsace.io to obtain the `Verified` role. That will give u typing abilities");
+            } catch (err) {
+                const ch = await (await discordGuild()).channels.fetch(config.discord.coreChannel);
+                (ch as TextChannel).send(`Failed to DM ${member.user.username} (${member.id})\n\`\`\`${err}\`\`\``);
+            }
+        }
 
         try {
             await member.roles.add(roles);
         } catch (err) {
             const ch = await (await discordGuild()).channels.fetch(config.discord.coreChannel);
-            (ch as TextChannel).send(`Failed to add roles to ${member.user.tag} (${member.id})\n\`\`\`${err}\`\`\``);
+            (ch as TextChannel).send(`Failed to add roles to ${member.user.username} (${member.id})\n\`\`\`${err}\`\`\``);
         }       
 
         const memberUser = member.user;
         const embed = new EmbedBuilder({
-            title: `${memberUser.tag} joined`,
+            title: `${memberUser.username} joined`,
             description: `Users currently in server: ${member.guild.memberCount}`,
             color: 3066993,
             timestamp: new Date(),
@@ -70,7 +76,7 @@ export default async function guildMemberAdd (member: GuildMember) {
             fields: [
                 {
                     name: "Registered?",
-                    value: user ? `${memberUser.tag} is registered` : `${memberUser.tag} isn't registered`,
+                    value: user ? `${memberUser.username} is registered` : `${memberUser.username} isn't registered`,
                 },
             ],
         } as EmbedData);

--- a/DiscordBot/handlers/guildMemberRemove.ts
+++ b/DiscordBot/handlers/guildMemberRemove.ts
@@ -8,7 +8,7 @@ export default async function guildMemberRemove (member: GuildMember | PartialGu
     const user = await discordClient.users.fetch(member.id);
     if (member.guild.id === config.discord.guild) {
         const embed = new EmbedBuilder({
-            title: `${user ? user.tag : "A user"} left`,
+            title: `${user ? user.username : "A user"} left`,
             description: `Users currently in server: ${member.guild.memberCount}`,
             color: 15277667,
             timestamp: new Date(),

--- a/Open/store/open.ts
+++ b/Open/store/open.ts
@@ -81,6 +81,8 @@ export const mutations: MutationTree<OpenState> = {
                 .sort((a, b) => (a.isRegistered ? 0 : 1) - (b.isRegistered ? 0 : 1));
     },
     async setTeam (state, teams: Team[] | undefined) {
+        teams = teams?.filter(team => !team.tournaments || !team.tournaments.some(tournament => tournament.ID !== state.tournament?.ID)); // TODO: Remove this when the website supports multiple teams for a user
+
         state.team = teams?.[0] || null;
         if (state.team?.qualifier)
             state.team.qualifier = {

--- a/Server/api/routes/team/index.ts
+++ b/Server/api/routes/team/index.ts
@@ -37,6 +37,7 @@ teamRouter.get("/", isLoggedInDiscord, async (ctx) => {
         .createQueryBuilder("team")
         .leftJoinAndSelect("team.manager", "manager")
         .leftJoinAndSelect("team.members", "member")
+        .leftJoinAndSelect("team.tournaments", "tournament")
         .leftJoinAndSelect("member.userStatistics", "stats")
         .leftJoinAndSelect("stats.modeDivision", "mode")
         .where("team.ID IN (:...teamIDs)", { teamIDs: teamIDs.map(t => t.ID) })
@@ -51,7 +52,8 @@ teamRouter.get("/all", async (ctx) => {
         .leftJoinAndSelect("team.manager", "manager")
         .leftJoinAndSelect("team.members", "member")
         .leftJoinAndSelect("member.userStatistics", "stats")
-        .leftJoinAndSelect("stats.modeDivision", "mode");
+        .leftJoinAndSelect("stats.modeDivision", "mode")
+        .leftJoinAndSelect("team.tournaments", "tournament");
 
     if (parseQueryParam(ctx.query.offset) && !isNaN(parseInt(parseQueryParam(ctx.query.offset)!)))
         teamQ.skip(parseInt(parseQueryParam(ctx.query.offset)!));

--- a/Server/discord.ts
+++ b/Server/discord.ts
@@ -22,7 +22,7 @@ discordClient.login(config.discord.token).catch(err => {
 
 // Ready instance for the bot
 discordClient.once("ready", () => {
-    console.log(`Logged into discord as ${discordClient.user?.tag}`);
+    console.log(`Logged into discord as ${discordClient.user?.username}`);
 });
 
 discordClient.on("error", err => {


### PR DESCRIPTION
Discord:
- Changed tag names to usernames cuz discriminators died
- Catch errors for trying to send users coming in Corsace

Teams:
- Filter teams registered in other teams not in Corsace Open so that the team that shows up for the user is either an unregistered team/or their Corsace Open team
- Reduce SQL queries cuz teamInterface calls for tournament and the tournament leftjoins kill those extra queries