### PR TITLE
Handle Discord Embed Limits

### DIFF
--- a/DiscordBot/commands/osu/beatmap.ts
+++ b/DiscordBot/commands/osu/beatmap.ts
@@ -132,8 +132,8 @@ async function run (m: Message | ChatInputCommandInteraction) {
     if (mods.includes("NC") && mods.includes("DT"))
         mods = mods.replace("DT", "");
 
-    const message = await beatmapEmbed(beatmap, mods, set, misses);
-    await respond(m, undefined, [message]);
+    const embed = await beatmapEmbed(beatmap, mods, set, misses);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/osu/profile.ts
+++ b/DiscordBot/commands/osu/profile.ts
@@ -1,4 +1,4 @@
-import { Message, EmbedBuilder, EmbedData, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { Message, ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { OsuOAuth, User } from "../../../Models/user";
 import { Command } from "../index";
 import { User as APIUser } from "nodesu";
@@ -8,6 +8,7 @@ import getUser from "../../../Server/functions/get/getUser";
 import commandUser from "../../functions/commandUser";
 import respond from "../../functions/respond";
 import { discordStringTimestamp } from "../../../Server/utils/dateParse";
+import { EmbedBuilder } from "../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -73,23 +74,19 @@ async function run (m: Message | ChatInputCommandInteraction) {
         user = userQ;
     }
     
-    const embedMsg: EmbedData = {
-        author: {
+    const embed = new EmbedBuilder()
+        .setAuthor({
             url: `https://osu.ppy.sh/users/${user.osu.userID}`,
             name: `${user.osu.username} (${user.osu.userID})`,
-            iconURL: `https://osu.ppy.sh/images/flags/${user.country}.png`,
-        },
-        description: `**PP:** ${apiUser.pp}\n **Rank:** #${apiUser.rank} (${user.country}#${apiUser.countryRank})\n **Acc:** ${apiUser.accuracy.toFixed(2)}%\n **Playcount:** ${apiUser.playcount}\n **SS**: ${apiUser.countRankSS} **S:** ${apiUser.countRankS} **A:** ${apiUser.countRankA}\n **Joined:** ${discordStringTimestamp(apiUser.joinDate)}`,
-        color: 0xFB2475,
-        footer: {
+            icon_url: `https://osu.ppy.sh/images/flags/${user.country}.png`,
+        })
+        .setDescription(`**PP:** ${apiUser.pp}\n **Rank:** #${apiUser.rank} (${user.country}#${apiUser.countryRank})\n **Acc:** ${apiUser.accuracy.toFixed(2)}%\n **Playcount:** ${apiUser.playcount}\n **SS**: ${apiUser.countRankSS} **S:** ${apiUser.countRankS} **A:** ${apiUser.countRankA}\n **Joined:** ${discordStringTimestamp(apiUser.joinDate)}`)
+        .setColor(0xFB2475)
+        .setFooter({
             text: `Corsace ID #${user.ID}`,
-        },
-        thumbnail: {
-            url: user.osu.avatar,
-        },
-    };
-    const message = new EmbedBuilder(embedMsg);
-    await respond(m, undefined, [message]);
+        })
+        .setThumbnail(user.osu.avatar);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/osu/profile.ts
+++ b/DiscordBot/commands/osu/profile.ts
@@ -8,7 +8,7 @@ import getUser from "../../../Server/functions/get/getUser";
 import commandUser from "../../functions/commandUser";
 import respond from "../../functions/respond";
 import { discordStringTimestamp } from "../../../Server/utils/dateParse";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/osu/recent.ts
+++ b/DiscordBot/commands/osu/recent.ts
@@ -149,7 +149,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
     let beatmap = ((await osuClient.beatmaps.getByBeatmapId(score.beatmapId, Mode.all, 1, undefined, score.enabledMods)) as Beatmap[])[0];
     beatmap = applyMods(beatmap, mods);
 
-    const message = await beatmapEmbed(beatmap, mods, user, undefined, score);
+    const embed = await beatmapEmbed(beatmap, mods, user, undefined, score);
 
     if (!(
         (m instanceof Message && /^(rb|recentb|recentbest)/i.test(m.content.substring(1))) ||
@@ -163,11 +163,11 @@ async function run (m: Message | ChatInputCommandInteraction) {
             else
                 break;
         }
-        message.setFooter({ text: `Try #${attempt} | <t:${score.date.getTime() / 1000}:R>` });
+        embed.setFooter({ text: `Try #${attempt} | <t:${score.date.getTime() / 1000}:R>` });
     } else
-        message.setFooter({ text: `<t:${score.date.getTime() / 1000}:R>` });
+        embed.setFooter({ text: `<t:${score.date.getTime() / 1000}:R>` });
 
-    await respond(m, warning, [message]);
+    await respond(m, warning, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/create.ts
+++ b/DiscordBot/commands/tournaments/create.ts
@@ -1,5 +1,5 @@
 import { config } from "node-config-ts";
-import { ActionRowBuilder, ChatInputCommandInteraction, Message, PermissionFlagsBits, SlashCommandBuilder, MessageComponentInteraction, StringSelectMenuBuilder, StringSelectMenuInteraction, EmbedBuilder, PermissionsBitField, ButtonBuilder, ButtonStyle, ChannelType, GuildChannelCreateOptions, ForumChannel } from "discord.js";
+import { ActionRowBuilder, ChatInputCommandInteraction, Message, PermissionFlagsBits, SlashCommandBuilder, MessageComponentInteraction, StringSelectMenuBuilder, StringSelectMenuInteraction, PermissionsBitField, ButtonBuilder, ButtonStyle, ChannelType, GuildChannelCreateOptions, ForumChannel } from "discord.js";
 import { ModeDivision, modeTextToID } from "../../../Models/MCA_AYIM/modeDivision";
 import { Tournament, TournamentStatus, sortTextToOrder } from "../../../Models/tournaments/tournament";
 import { User } from "../../../Models/user";
@@ -20,6 +20,7 @@ import { cron } from "../../../Server/cron";
 import { CronJobType } from "../../../Interfaces/cron";
 import { StageType } from "../../../Interfaces/stage";
 import { TournamentRoleType, TournamentChannelType, getTournamentChannelTypeRoles, forumTags } from "../../../Interfaces/tournament";
+import { EmbedBuilder } from "../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))
@@ -873,15 +874,15 @@ async function tournamentSave (m: Message, tournament: Tournament) {
             { name: "Invitational", value: tournament.invitational ? "Yes" : "No", inline: true },
             { name: "Server", value: tournament.server, inline: true }
         )
-        .setTimestamp(new Date())
-        .setAuthor({ name: m.author.username, iconURL: m.member?.avatarURL() ?? undefined });
+        .setTimestamp()
+        .setAuthor({ name: m.author.username, icon_url: m.member?.avatarURL() ?? undefined });
 
     if (tournament.isOpen || tournament.isClosed)
         embed.addFields(
             { name: "Corsace", value: tournament.isOpen ? "Open" : "Closed", inline: true }
         );
 
-    await m.reply({ content: "Nice u saved the tournament!!!1\nHere's the tournament embed:", embeds: [embed] });
+    await respond(m, "Nice u saved the tournament!!!1\nHere's the tournament embed:", embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/create.ts
+++ b/DiscordBot/commands/tournaments/create.ts
@@ -20,7 +20,7 @@ import { cron } from "../../../Server/cron";
 import { CronJobType } from "../../../Interfaces/cron";
 import { StageType } from "../../../Interfaces/stage";
 import { TournamentRoleType, TournamentChannelType, getTournamentChannelTypeRoles, forumTags } from "../../../Interfaces/tournament";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))

--- a/DiscordBot/commands/tournaments/edit.ts
+++ b/DiscordBot/commands/tournaments/edit.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
 import { Command } from "..";
 import getUser from "../../../Server/functions/get/getUser";
 import commandUser from "../../functions/commandUser";
@@ -13,6 +13,7 @@ import { ModeDivision, modeTextHash, modeTextToID } from "../../../Models/MCA_AY
 import { discordStringTimestamp, parseDateOrTimestamp } from "../../../Server/utils/dateParse";
 import { StageType } from "../../../Interfaces/stage";
 import { ModeDivisionType } from "../../../Interfaces/modes";
+import { EmbedBuilder } from "../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))
@@ -284,15 +285,15 @@ async function tournamentSave (m: Message, tournament: Tournament) {
             { name: "Invitational", value: tournament.invitational ? "Yes" : "No", inline: true },
             { name: "Server", value: tournament.server, inline: true }
         )
-        .setTimestamp(new Date())
-        .setAuthor({ name: m.author.username, iconURL: m.member?.avatarURL() ?? undefined });
+        .setTimestamp()
+        .setAuthor({ name: m.author.username, icon_url: m.member?.avatarURL() ?? undefined });
 
     if (tournament.isOpen || tournament.isClosed)
         embed.addFields(
             { name: "Corsace", value: tournament.isOpen ? "Open" : "Closed", inline: true }
         );
 
-    await m.reply({ content: "Nice u saved the tournament!!!1\nHere's the tournament embed:", embeds: [embed] });
+    await respond(m, "Nice u saved the tournament!!!1\nHere's the tournament embed:", embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/edit.ts
+++ b/DiscordBot/commands/tournaments/edit.ts
@@ -13,7 +13,7 @@ import { ModeDivision, modeTextHash, modeTextToID } from "../../../Models/MCA_AY
 import { discordStringTimestamp, parseDateOrTimestamp } from "../../../Server/utils/dateParse";
 import { StageType } from "../../../Interfaces/stage";
 import { ModeDivisionType } from "../../../Interfaces/modes";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))

--- a/DiscordBot/commands/tournaments/info.ts
+++ b/DiscordBot/commands/tournaments/info.ts
@@ -12,7 +12,7 @@ import { TournamentRole } from "../../../Models/tournaments/tournamentRole";
 import { Stage } from "../../../Models/tournaments/stage";
 import { TournamentChannel } from "../../../Models/tournaments/tournamentChannel";
 import { TournamentChannelType, TournamentRoleType } from "../../../Interfaces/tournament";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 
 const info_typeToFunction = {
     "Stages": stageInfos,

--- a/DiscordBot/commands/tournaments/info.ts
+++ b/DiscordBot/commands/tournaments/info.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from "discord.js";
 import { Command } from "..";
 import getTournament from "../../functions/tournamentFunctions/getTournament";
 import channelID from "../../functions/channelID";
@@ -12,6 +12,7 @@ import { TournamentRole } from "../../../Models/tournaments/tournamentRole";
 import { Stage } from "../../../Models/tournaments/stage";
 import { TournamentChannel } from "../../../Models/tournaments/tournamentChannel";
 import { TournamentChannelType, TournamentRoleType } from "../../../Interfaces/tournament";
+import { EmbedBuilder } from "../../functions/embedHandlers";
 
 const info_typeToFunction = {
     "Stages": stageInfos,
@@ -89,7 +90,7 @@ async function stageInfos (m: Message<boolean> | ChatInputCommandInteraction, to
         })
     );
 
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 async function roleInfos (m: Message<boolean> | ChatInputCommandInteraction, tournament: Tournament, embed: EmbedBuilder) {
@@ -108,7 +109,7 @@ async function roleInfos (m: Message<boolean> | ChatInputCommandInteraction, tou
         })
     );
 
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 async function channelInfos (m: Message<boolean> | ChatInputCommandInteraction, tournament: Tournament, embed: EmbedBuilder) {
@@ -127,7 +128,7 @@ async function channelInfos (m: Message<boolean> | ChatInputCommandInteraction, 
         })
     );
 
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/mappool/assign.ts
+++ b/DiscordBot/commands/tournaments/mappool/assign.ts
@@ -169,9 +169,9 @@ async function handleBeatmapLink (m: Message | ChatInputCommandInteraction, targ
     if (allowedMods)
         apiMap = (await osuClient.beatmaps.getBySetId(parseInt(link[1]), undefined, undefined, undefined, allowedMods) as APIBeatmap[]).find(m => m.beatmapId === beatmapID)!;
     const mappoolMapEmbed = await beatmapEmbed(apiMap, mod, set);
-    mappoolMapEmbed.data.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.data.author!.name}`;
+    mappoolMapEmbed.embed.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.embed.author!.name}`;
 
-    await respond(m, `Set **${mappoolSlot}** to **${beatmap.beatmapset.artist} - ${beatmap.beatmapset.title} [${beatmap.difficulty}]**`, [mappoolMapEmbed]);
+    await respond(m, `Set **${mappoolSlot}** to **${beatmap.beatmapset.artist} - ${beatmap.beatmapset.title} [${beatmap.difficulty}]**`, mappoolMapEmbed);
 
     await mappoolLog(tournament, "assignMap", assigner, log, mappoolSlot);
     return;

--- a/DiscordBot/commands/tournaments/mappool/assignments.ts
+++ b/DiscordBot/commands/tournaments/mappool/assignments.ts
@@ -1,4 +1,4 @@
-import { Message, EmbedBuilder, SlashCommandBuilder, ChatInputCommandInteraction, ChannelType, TextChannel } from "discord.js";
+import { Message, EmbedBuilder, SlashCommandBuilder, ChatInputCommandInteraction, ChannelType } from "discord.js";
 import { Command } from "../../index";
 import { MappoolSlot } from "../../../../Models/tournaments/mappools/mappoolSlot";
 import { Brackets } from "typeorm";
@@ -59,29 +59,16 @@ async function assignmentListDM (m: Message | ChatInputCommandInteraction) {
         .setTimestamp(new Date())
         .setFields();
 
-    let replied = false;
     for (const map of mappoolMaps) {
         embed.addFields(
             { name: `**${map.slot.mappool.stage.tournament.abbreviation}** ${map.slot.mappool.abbreviation.toUpperCase()} ${map.slot.acronym}${map.order}`, value: `${map.customBeatmap ? `${map.customBeatmap.artist} - ${map.customBeatmap.title} [${map.customBeatmap.difficulty}]` : "No Submitted Beatmap"}\nDeadline: ${map.deadline ? discordStringTimestamp(map.deadline) : "No Deadline For Beatmap"}`, inline: true }
         );
-
-        if (embed.data.fields!.length === 25) {
-            if (!replied) {
-                await respond(m, undefined, [embed]);
-                replied = true;
-            } else {
-                await (m.channel as TextChannel).send({ embeds: [embed] });
-            }
-            embed.data.fields = [];
-        }
     }    
 
-    if (!replied || embed.data.fields!.length > 0) {
-        if (embed.data.fields!.length === 0)
-            embed.addFields({ name: "No Maps Found", value: "No maps found with the given parameters"});
-        
-        await respond(m, undefined, [embed]);
-    }
+    if (embed.data.fields!.length === 0)
+        embed.addFields({ name: "No Maps Found", value: "No maps found with the given parameters"});
+
+    await respond(m, undefined, [embed]);
 }
 
 async function run (m: Message | ChatInputCommandInteraction) {
@@ -159,7 +146,6 @@ async function run (m: Message | ChatInputCommandInteraction) {
         .setTimestamp(new Date())
         .setFields();
 
-    let replied = false;
     for (const map of mappoolMaps) {
         const beatmapText = map.customBeatmap ? `${map.customBeatmap.artist} - ${map.customBeatmap.title} [${map.customBeatmap.difficulty}]\n` : "";
         const customMappers = map.customMappers.length > 0 ? `Custom Mappers: **${map.customMappers.map(u => u.osu.username).join(", ")}**\n` : "";
@@ -174,25 +160,12 @@ async function run (m: Message | ChatInputCommandInteraction) {
                     value,
                     inline: true }
             );
-
-        if (embed.data.fields!.length !== 25)
-            continue;
-
-        if (!replied) {
-            await respond(m, undefined, [embed]);
-            replied = true;
-        } else
-            await (m.channel as TextChannel).send({ embeds: [embed] });
-        embed.data.fields = [];
     }
 
-    if (!replied || embed.data.fields!.length > 0) {
-        if (embed.data.fields!.length === 0)
-            embed.addFields({ name: "No Maps Found", value: "No maps found with the given parameters GJ ."});
+    if (embed.data.fields!.length === 0)
+        embed.addFields({ name: "No Maps Found", value: "No maps found with the given parameters GJ ."});
         
-        replied ? await respond(m, undefined, [embed]) : await m.channel?.send({ embeds: [embed] });
-    }
-
+    await respond(m, undefined, [embed]);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/mappool/assignments.ts
+++ b/DiscordBot/commands/tournaments/mappool/assignments.ts
@@ -13,7 +13,7 @@ import getStaff from "../../../functions/tournamentFunctions/getStaff";
 import getTournament from "../../../functions/tournamentFunctions/getTournament";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { TournamentRoleType, TournamentChannelType } from "../../../../Interfaces/tournament";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function assignmentListDM (m: Message | ChatInputCommandInteraction) {
     // Check if they had -incfin in their text, or if they said true for the include_finished option in the slash command

--- a/DiscordBot/commands/tournaments/mappool/assignments.ts
+++ b/DiscordBot/commands/tournaments/mappool/assignments.ts
@@ -63,7 +63,10 @@ async function assignmentListDM (m: Message | ChatInputCommandInteraction) {
         embed.addFields(
             { name: `**${map.slot.mappool.stage.tournament.abbreviation}** ${map.slot.mappool.abbreviation.toUpperCase()} ${map.slot.acronym}${map.order}`, value: `${map.customBeatmap ? `${map.customBeatmap.artist} - ${map.customBeatmap.title} [${map.customBeatmap.difficulty}]` : "No Submitted Beatmap"}\nDeadline: ${map.deadline ? discordStringTimestamp(map.deadline) : "No Deadline For Beatmap"}`, inline: true }
         );
-    }    
+    }
+
+    if (!embed.embed.fields || embed.embed.fields.length === 0)
+        embed.addField({ name: "No Maps Found", value: "No maps found with the given parameters"});
 
     await respond(m, undefined, embed);
 }
@@ -157,6 +160,9 @@ async function run (m: Message | ChatInputCommandInteraction) {
                     inline: true }
             );
     }
+
+    if (!embed.embed.fields || embed.embed.fields.length === 0)
+        embed.addField({ name: "No Maps Found", value: "No maps found with the given parameters"});
         
     await respond(m, undefined, embed);
 }

--- a/DiscordBot/commands/tournaments/mappool/assignments.ts
+++ b/DiscordBot/commands/tournaments/mappool/assignments.ts
@@ -1,4 +1,4 @@
-import { Message, EmbedBuilder, SlashCommandBuilder, ChatInputCommandInteraction, ChannelType } from "discord.js";
+import { Message, SlashCommandBuilder, ChatInputCommandInteraction, ChannelType } from "discord.js";
 import { Command } from "../../index";
 import { MappoolSlot } from "../../../../Models/tournaments/mappools/mappoolSlot";
 import { Brackets } from "typeorm";
@@ -13,6 +13,7 @@ import getStaff from "../../../functions/tournamentFunctions/getStaff";
 import getTournament from "../../../functions/tournamentFunctions/getTournament";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { TournamentRoleType, TournamentChannelType } from "../../../../Interfaces/tournament";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function assignmentListDM (m: Message | ChatInputCommandInteraction) {
     // Check if they had -incfin in their text, or if they said true for the include_finished option in the slash command
@@ -56,8 +57,7 @@ async function assignmentListDM (m: Message | ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
         .setTitle("Mappool Assignments")
         .setDescription(`Here are ur current mappool assignments`)
-        .setTimestamp(new Date())
-        .setFields();
+        .setTimestamp();
 
     for (const map of mappoolMaps) {
         embed.addFields(
@@ -65,10 +65,7 @@ async function assignmentListDM (m: Message | ChatInputCommandInteraction) {
         );
     }    
 
-    if (embed.data.fields!.length === 0)
-        embed.addFields({ name: "No Maps Found", value: "No maps found with the given parameters"});
-
-    await respond(m, undefined, [embed]);
+    await respond(m, undefined, embed);
 }
 
 async function run (m: Message | ChatInputCommandInteraction) {
@@ -143,8 +140,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
         .setTitle("Mappool Assignments")
         .setDescription(`Here are the current mappool assignments${pool ?? targetUser ? ` with the given parameters: **${pool ? `pool: \`${pool}\` ` : ""}${targetUser ? `user: \`${targetUser.osu.username}|${targetUser.discord.username}\`` : ""}**` : ``}`)
-        .setTimestamp(new Date())
-        .setFields();
+        .setTimestamp();
 
     for (const map of mappoolMaps) {
         const beatmapText = map.customBeatmap ? `${map.customBeatmap.artist} - ${map.customBeatmap.title} [${map.customBeatmap.difficulty}]\n` : "";
@@ -161,11 +157,8 @@ async function run (m: Message | ChatInputCommandInteraction) {
                     inline: true }
             );
     }
-
-    if (embed.data.fields!.length === 0)
-        embed.addFields({ name: "No Maps Found", value: "No maps found with the given parameters GJ ."});
         
-    await respond(m, undefined, [embed]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/mappool/create.ts
+++ b/DiscordBot/commands/tournaments/mappool/create.ts
@@ -1,4 +1,4 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, EmbedBuilder, Message, MessageComponentInteraction, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, Message, MessageComponentInteraction, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
 import { Command } from "../..";
 import { Mappool } from "../../../../Models/tournaments/mappools/mappool";
 import { MappoolMap } from "../../../../Models/tournaments/mappools/mappoolMap";
@@ -18,6 +18,7 @@ import confirmCommand from "../../../functions/confirmCommand";
 import channelID from "../../../functions/channelID";
 import mappoolLog from "../../../functions/tournamentFunctions/mappoolLog";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))
@@ -443,7 +444,7 @@ async function mappoolDone (m: Message, mappool: Mappool, tournament: Tournament
             }));
 
     await Promise.all([
-        m.channel.send({ embeds: [embed] }),
+        respond(m, undefined, embed),
         mappoolLog(tournament, "mappoolCreate", mappool.createdBy, `Created mappool ${mappool.name} (${mappool.abbreviation.toUpperCase()})`),
     ]);
 }

--- a/DiscordBot/commands/tournaments/mappool/create.ts
+++ b/DiscordBot/commands/tournaments/mappool/create.ts
@@ -18,7 +18,7 @@ import confirmCommand from "../../../functions/confirmCommand";
 import channelID from "../../../functions/channelID";
 import mappoolLog from "../../../functions/tournamentFunctions/mappoolLog";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))

--- a/DiscordBot/commands/tournaments/mappool/edit.ts
+++ b/DiscordBot/commands/tournaments/mappool/edit.ts
@@ -17,7 +17,7 @@ import getCustomThread from "../../../functions/tournamentFunctions/getCustomThr
 import { discordClient } from "../../../../Server/discord";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
 import { TournamentRoleType } from "../../../../Interfaces/tournament";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/mappool/edit.ts
+++ b/DiscordBot/commands/tournaments/mappool/edit.ts
@@ -1,4 +1,4 @@
-import { Message, SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder, ThreadChannel } from "discord.js";
+import { Message, SlashCommandBuilder, ChatInputCommandInteraction, ThreadChannel } from "discord.js";
 import { Command } from "../../index";
 import respond from "../../../functions/respond";
 import { extractParameter } from "../../../functions/parameterFunctions";
@@ -17,6 +17,7 @@ import getCustomThread from "../../../functions/tournamentFunctions/getCustomThr
 import { discordClient } from "../../../../Server/discord";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
 import { TournamentRoleType } from "../../../../Interfaces/tournament";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -168,11 +169,11 @@ async function mappoolSave (m: Message, mappool: Mappool, tournament: Tournament
                     value: `${slot.maps.length} map${slot.maps.length > 1 ? "s" : ""}`,
                 };
             }))
-        .setTimestamp(new Date())
-        .setAuthor({ name: commandUser(m).username, iconURL: m.member?.displayAvatarURL() ?? undefined });
+        .setTimestamp()
+        .setAuthor({ name: commandUser(m).username, icon_url: m.member?.displayAvatarURL() ?? undefined });
 
     await Promise.all([
-        m.channel.send({ embeds: [embed] }),
+        await respond(m, undefined, embed),
         mappoolLog(tournament, "mappoolEdit", user, `Edited mappool ${mappool.name} (${mappool.abbreviation.toUpperCase()})`),
     ]);
 }

--- a/DiscordBot/commands/tournaments/mappool/finish.ts
+++ b/DiscordBot/commands/tournaments/mappool/finish.ts
@@ -114,9 +114,9 @@ async function run (m: Message | ChatInputCommandInteraction) {
     if (slotMod.allowedMods)
         apiMap = (await osuClient.beatmaps.getBySetId(parseInt(link[1]), undefined, undefined, undefined, slotMod.allowedMods) as APIBeatmap[]).find(m => m.beatmapId === beatmapID)!;
     const mappoolMapEmbed = await beatmapEmbed(apiMap, slot, set);
-    mappoolMapEmbed.data.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.data.author!.name}`;
+    mappoolMapEmbed.embed.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.embed.author!.name}`;
 
-    await respond(m, `Set **${mappoolSlot}** as finished, and to **${beatmap.beatmapset.artist} - ${beatmap.beatmapset.title} [${beatmap.difficulty}]**`, [mappoolMapEmbed]);
+    await respond(m, `Set **${mappoolSlot}** as finished, and to **${beatmap.beatmapset.artist} - ${beatmap.beatmapset.title} [${beatmap.difficulty}]**`, mappoolMapEmbed);
 
     await mappoolLog(tournament, "finishedMap", assigner, log, mappoolSlot);
     return;

--- a/DiscordBot/commands/tournaments/mappool/history.ts
+++ b/DiscordBot/commands/tournaments/mappool/history.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder, TextChannel } from "discord.js";
+import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
 import { extractParameters } from "../../../functions/parameterFunctions";
 import { postProcessSlotOrder } from "../../../functions/tournamentFunctions/parameterPostProcessFunctions";
 import { securityChecks } from "../../../functions/tournamentFunctions/securityChecks";
@@ -50,32 +50,18 @@ async function run (m: Message | ChatInputCommandInteraction) {
         .setDescription(`**CURRENT VERSION:** ${mappoolMap.beatmap ? `${mappoolMap.beatmap.beatmapset.artist} - ${mappoolMap.beatmap.beatmapset.title} [${mappoolMap.beatmap.difficulty}]` : mappoolMap.customBeatmap ? `${mappoolMap.customBeatmap.artist} - ${mappoolMap.customBeatmap.title} [${mappoolMap.customBeatmap.difficulty}]` : "No map"}`)
         .setColor(modeColour(tournament.mode.ID - 1))
         .setFields();
-    
-    let replied = false;
+
     for (const h of history) {
         embed.addFields({
             name: `Added by ${h.createdBy.osu.username}`,
             value: discordStringTimestamp(h.createdAt) + "\n" + (h.beatmap ? `**Beatmap:** ${h.beatmap.beatmapset.artist} - ${h.beatmap.beatmapset.title} [${h.beatmap.difficulty}]` : h.artist ? `**Custom:** ${h.artist} - ${h.title} [${h.difficulty}]\n${h.link}` : "No map(? Shouldn't happen tell VINXIS)"),
         });
-
-        if (embed.data.fields!.length === 25) {
-            if (!replied) {
-                await respond(m, undefined, [embed]);
-                replied = true;
-            } else
-                await (m.channel as TextChannel).send({ embeds: [embed] });
-
-            embed.data.fields = [];
-        }
     }
 
-    if (!replied || embed.data.fields!.length > 0) {
-        if (embed.data.fields!.length === 0)
-            embed.addFields({ name: "No History Found", value: "No history found for this given slot GJ ."});
+    if (embed.data.fields!.length === 0)
+        embed.addFields({ name: "No History Found", value: "No history found for this given slot GJ ."});
         
-        replied ? await respond(m, undefined, [embed]) : await m.channel?.send({ embeds: [embed] });
-    }
-
+    await respond(m, undefined, [embed]);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/mappool/history.ts
+++ b/DiscordBot/commands/tournaments/mappool/history.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from "discord.js";
 import { extractParameters } from "../../../functions/parameterFunctions";
 import { postProcessSlotOrder } from "../../../functions/tournamentFunctions/parameterPostProcessFunctions";
 import { securityChecks } from "../../../functions/tournamentFunctions/securityChecks";
@@ -9,6 +9,7 @@ import { Command } from "../..";
 import modeColour from "../../../functions/modeColour";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { TournamentRoleType, TournamentChannelType } from "../../../../Interfaces/tournament";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -48,8 +49,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
         .setTitle(`History of ${mappoolSlot}`)
         .setDescription(`**CURRENT VERSION:** ${mappoolMap.beatmap ? `${mappoolMap.beatmap.beatmapset.artist} - ${mappoolMap.beatmap.beatmapset.title} [${mappoolMap.beatmap.difficulty}]` : mappoolMap.customBeatmap ? `${mappoolMap.customBeatmap.artist} - ${mappoolMap.customBeatmap.title} [${mappoolMap.customBeatmap.difficulty}]` : "No map"}`)
-        .setColor(modeColour(tournament.mode.ID - 1))
-        .setFields();
+        .setColor(modeColour(tournament.mode.ID - 1));
 
     for (const h of history) {
         embed.addFields({
@@ -57,11 +57,8 @@ async function run (m: Message | ChatInputCommandInteraction) {
             value: discordStringTimestamp(h.createdAt) + "\n" + (h.beatmap ? `**Beatmap:** ${h.beatmap.beatmapset.artist} - ${h.beatmap.beatmapset.title} [${h.beatmap.difficulty}]` : h.artist ? `**Custom:** ${h.artist} - ${h.title} [${h.difficulty}]\n${h.link}` : "No map(? Shouldn't happen tell VINXIS)"),
         });
     }
-
-    if (embed.data.fields!.length === 0)
-        embed.addFields({ name: "No History Found", value: "No history found for this given slot GJ ."});
         
-    await respond(m, undefined, [embed]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/mappool/history.ts
+++ b/DiscordBot/commands/tournaments/mappool/history.ts
@@ -9,7 +9,7 @@ import { Command } from "../..";
 import modeColour from "../../../functions/modeColour";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { TournamentRoleType, TournamentChannelType } from "../../../../Interfaces/tournament";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/mappool/info.ts
+++ b/DiscordBot/commands/tournaments/mappool/info.ts
@@ -15,6 +15,7 @@ import { securityChecks } from "../../../functions/tournamentFunctions/securityC
 import channelID from "../../../functions/channelID";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { TournamentRoleType, TournamentChannelType } from "../../../../Interfaces/tournament";
+import customBeatmapToNodesu from "../../../../Server/functions/tournaments/mappool/customBeatmapToNodesu";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -86,68 +87,8 @@ async function run (m: Message | ChatInputCommandInteraction) {
             return;
         }
 
-        const apiBeatmap = new APIBeatmap({
-            "beatmapset_id": "-1",
-            "beatmap_id": "-1",
-            "approved": "-3",
-            "total_length": `${mappoolMap.customBeatmap.totalLength}`,
-            "hit_length": `${mappoolMap.customBeatmap.hitLength}`,
-            "version": mappoolMap.customBeatmap.difficulty,
-            "file_md5": "",
-            "diff_size": `${mappoolMap.customBeatmap.circleSize}`,
-            "diff_overall": `${mappoolMap.customBeatmap.overallDifficulty}`,
-            "diff_approach": `${mappoolMap.customBeatmap.approachRate}`,
-            "diff_drain": `${mappoolMap.customBeatmap.hpDrain}`,
-            "mode": `${mappoolMap.customBeatmap.mode.ID - 1}`,
-            "count_normal": `${mappoolMap.customBeatmap.circles}`,
-            "count_slider": `${mappoolMap.customBeatmap.sliders}`,
-            "count_spinner": `${mappoolMap.customBeatmap.spinners}`,
-            "submit_date": [
-                mappoolMap.createdAt.getUTCMonth() + 1,
-                mappoolMap.createdAt.getUTCDate(),
-                mappoolMap.createdAt.getUTCFullYear(),
-            ].join("/") + " " + [
-                mappoolMap.createdAt.getUTCHours(),
-                mappoolMap.createdAt.getUTCMinutes(),
-                mappoolMap.createdAt.getUTCSeconds(),
-            ].join(":"),
-            "approved_date": null,
-            "last_update": [
-                mappoolMap.lastUpdate.getUTCMonth() + 1,
-                mappoolMap.lastUpdate.getUTCDate(),
-                mappoolMap.lastUpdate.getUTCFullYear(),
-            ].join("/") + " " + [
-                mappoolMap.lastUpdate.getUTCHours(),
-                mappoolMap.lastUpdate.getUTCMinutes(),
-                mappoolMap.lastUpdate.getUTCSeconds(),
-            ].join(":"),
-            "artist": mappoolMap.customBeatmap.artist,
-            "artist_unicode": mappoolMap.customBeatmap.artist,
-            "title": mappoolMap.customBeatmap.title,
-            "title_unicode": mappoolMap.customBeatmap.title,
-            "creator": mappoolMap.customMappers.map(u => u.osu.username).join(", "),
-            "creator_id": "-1",
-            "bpm": `${mappoolMap.customBeatmap.BPM}`,
-            "source": "",
-            "tags": `${mappoolMap.customBeatmap.link ?? ""}`,
-            "genre_id": "0",
-            "language_id": "0",
-            "favourite_count": "0",
-            "rating": "0",
-            "storyboard": "0",
-            "video": "0",
-            "download_unavailable": "0",
-            "audio_unavailable": "0",
-            "playcount": "0",
-            "passcount": "0",
-            "packs": null,
-            "max_combo": mappoolMap.customBeatmap.maxCombo ? `${mappoolMap.customBeatmap.maxCombo}` : null,
-            "diff_aim": mappoolMap.customBeatmap.aimSR ? `${mappoolMap.customBeatmap.aimSR}` : null,
-            "diff_speed": mappoolMap.customBeatmap.speedSR ? `${mappoolMap.customBeatmap.speedSR}` : null,
-            "difficultyrating": `${mappoolMap.customBeatmap.totalSR}`,
-        });
-        const set = [apiBeatmap];
-        const mappoolMapEmbed = await beatmapEmbed(applyMods(apiBeatmap, modsToAcronym(slotMod.allowedMods ?? 0)), modsToAcronym(slotMod.allowedMods ?? 0), set);
+        const nodesuBeatmap = customBeatmapToNodesu({...mappoolMap, customBeatmap: mappoolMap.customBeatmap});
+        const mappoolMapEmbed = await beatmapEmbed(applyMods(nodesuBeatmap, modsToAcronym(slotMod.allowedMods ?? 0)), modsToAcronym(slotMod.allowedMods ?? 0), [nodesuBeatmap]);
         mappoolMapEmbed.data.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.data.author!.name}`;
         
         await respond(m, `Info for **${mappoolSlot}**:\n\n${mappoolMap.customThreadID ? `Thread: <#${mappoolMap.customThreadID}>\n` : ""}${mappoolMap.deadline ? `Deadline: ${discordStringTimestamp(mappoolMap.deadline)}` : ""}`, [mappoolMapEmbed]);

--- a/DiscordBot/commands/tournaments/mappool/info.ts
+++ b/DiscordBot/commands/tournaments/mappool/info.ts
@@ -16,7 +16,7 @@ import channelID from "../../../functions/channelID";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { TournamentRoleType, TournamentChannelType } from "../../../../Interfaces/tournament";
 import customBeatmapToNodesu from "../../../../Server/functions/tournaments/mappool/customBeatmapToNodesu";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/mappool/jobBoard/info.ts
+++ b/DiscordBot/commands/tournaments/mappool/jobBoard/info.ts
@@ -9,7 +9,7 @@ import mappoolComponents from "../../../../functions/tournamentFunctions/mappool
 import { unFinishedTournaments } from "../../../../../Models/tournaments/tournament";
 import channelID from "../../../../functions/channelID";
 import { TournamentRoleType, TournamentChannelType } from "../../../../../Interfaces/tournament";
-import { EmbedBuilder } from "../../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/mappool/jobBoard/info.ts
+++ b/DiscordBot/commands/tournaments/mappool/jobBoard/info.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, GuildMember, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, GuildMember, Message, SlashCommandBuilder } from "discord.js";
 import { Command } from "../../../index";
 import modeColour from "../../../../functions/modeColour";
 import respond from "../../../../functions/respond";
@@ -9,6 +9,7 @@ import mappoolComponents from "../../../../functions/tournamentFunctions/mappool
 import { unFinishedTournaments } from "../../../../../Models/tournaments/tournament";
 import channelID from "../../../../functions/channelID";
 import { TournamentRoleType, TournamentChannelType } from "../../../../../Interfaces/tournament";
+import { EmbedBuilder } from "../../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -54,23 +55,22 @@ async function run (m: Message | ChatInputCommandInteraction) {
         return;
     }
 
-    const jobBoardEmbed = new EmbedBuilder()
+    const embed = new EmbedBuilder()
         .setTitle(`${mappool.name} Job Board`)
         .setColor(modeColour(tournament.mode.ID - 1))
         .setFooter({
             text: `Requested by ${m.member?.user.username}`,
-            iconURL: (m.member as GuildMember | null)?.displayAvatarURL() ?? undefined,
+            icon_url: (m.member as GuildMember | null)?.displayAvatarURL() ?? undefined,
         })
-        .setTimestamp();
+        .setTimestamp()
+        .addFields(mappool.slots.map(slot => {
+            return {
+                name: `**${slot.name}**`,
+                value: slot.maps.map(map => `**${slot.acronym}${slot.maps.length === 1 ? "" : map.order}:** ${map.jobPost && (all ? true : !map.jobPost.jobBoardThread) ? map.jobPost.description : map.jobPost?.jobBoardThread ? "**PUBLISHED**" : "N/A"}`).join("\n\n"),
+            };
+        }));
 
-    jobBoardEmbed.setFields(mappool.slots.map(slot => {
-        return {
-            name: `**${slot.name}**`,
-            value: slot.maps.map(map => `**${slot.acronym}${slot.maps.length === 1 ? "" : map.order}:** ${map.jobPost && (all ? true : !map.jobPost.jobBoardThread) ? map.jobPost.description : map.jobPost?.jobBoardThread ? "**PUBLISHED**" : "N/A"}`).join("\n\n"),
-        };
-    }));
-
-    await respond(m, undefined, [jobBoardEmbed]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/matchup/list.ts
+++ b/DiscordBot/commands/tournaments/matchup/list.ts
@@ -12,7 +12,7 @@ import getStaff from "../../../functions/tournamentFunctions/getStaff";
 import channelID from "../../../functions/channelID";
 import { Matchup } from "../../../../Models/tournaments/matchup";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 const refValues = ["referee", "ref", "r", "referees", "refs", "rs"] as const;
 const commentValues = ["commentator", "comment", "c", "commentators", "comments", "cs"] as const;

--- a/DiscordBot/commands/tournaments/matchup/list.ts
+++ b/DiscordBot/commands/tournaments/matchup/list.ts
@@ -1,4 +1,4 @@
-import { Message, EmbedBuilder, SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
+import { Message, SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
 import { Command } from "../../index";
 import { loginResponse } from "../../../functions/loginResponse";
 import { extractParameters } from "../../../functions/parameterFunctions";
@@ -12,6 +12,7 @@ import getStaff from "../../../functions/tournamentFunctions/getStaff";
 import channelID from "../../../functions/channelID";
 import { Matchup } from "../../../../Models/tournaments/matchup";
 import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 const refValues = ["referee", "ref", "r", "referees", "refs", "rs"] as const;
 const commentValues = ["commentator", "comment", "c", "commentators", "comments", "cs"] as const;
@@ -114,8 +115,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
         .setTitle("Matchups")
         .setDescription(`Here are the current matchups${filter === "assigned" ? " with u as a ref streamer or comm" : filter === "unassigned" ? " that r unassigned" : filter === "team" ? " with u as a team member/manager" : ""}`)
-        .setTimestamp(new Date())
-        .setFields();
+        .setTimestamp();
 
     for (const matchup of matchups) {
         const team1 = matchup.team1 ? `${matchup.team1.name} (${matchup.team1.abbreviation})` : "TBD";
@@ -133,11 +133,8 @@ async function run (m: Message | ChatInputCommandInteraction) {
                 }
             );
     }
-
-    if (embed.data.fields!.length === 0)
-        embed.addFields({ name: "No Matchups Found", value: "No matchups found with the given parameters GJ ."});
         
-    await respond(m, undefined, [embed]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/matchup/list.ts
+++ b/DiscordBot/commands/tournaments/matchup/list.ts
@@ -1,4 +1,4 @@
-import { Message, EmbedBuilder, SlashCommandBuilder, ChatInputCommandInteraction,  TextChannel } from "discord.js";
+import { Message, EmbedBuilder, SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
 import { Command } from "../../index";
 import { loginResponse } from "../../../functions/loginResponse";
 import { extractParameters } from "../../../functions/parameterFunctions";
@@ -117,7 +117,6 @@ async function run (m: Message | ChatInputCommandInteraction) {
         .setTimestamp(new Date())
         .setFields();
 
-    let replied = false;
     for (const matchup of matchups) {
         const team1 = matchup.team1 ? `${matchup.team1.name} (${matchup.team1.abbreviation})` : "TBD";
         const team2 = matchup.team2 ? `${matchup.team2.name} (${matchup.team2.abbreviation})` : "TBD";
@@ -133,24 +132,12 @@ async function run (m: Message | ChatInputCommandInteraction) {
                     inline: true,
                 }
             );
-
-        if (embed.data.fields!.length !== 25)
-            continue;
-
-        if (!replied) {
-            await respond(m, undefined, [embed]);
-            replied = true;
-        } else
-            await (m.channel as TextChannel).send({ embeds: [embed] });
-        embed.data.fields = [];
     }
 
-    if (!replied || embed.data.fields!.length > 0) {
-        if (embed.data.fields!.length === 0)
-            embed.addFields({ name: "No Matchups Found", value: "No matchups found with the given parameters GJ ."});
+    if (embed.data.fields!.length === 0)
+        embed.addFields({ name: "No Matchups Found", value: "No matchups found with the given parameters GJ ."});
         
-        replied ? await respond(m, undefined, [embed]) : await m.channel?.send({ embeds: [embed] });
-    }
+    await respond(m, undefined, [embed]);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/stage/create.ts
+++ b/DiscordBot/commands/tournaments/stage/create.ts
@@ -13,7 +13,7 @@ import getTournament from "../../../functions/tournamentFunctions/getTournament"
 import channelID from "../../../functions/channelID";
 import { discordStringTimestamp, parseDateOrTimestamp } from "../../../../Server/utils/dateParse";
 import { ScoringMethod, StageType } from "../../../../Interfaces/stage";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))

--- a/DiscordBot/commands/tournaments/stage/create.ts
+++ b/DiscordBot/commands/tournaments/stage/create.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, GuildMember, Message, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, GuildMember, Message, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
 import { Command } from "../..";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
 import { Round } from "../../../../Models/tournaments/round";
@@ -13,6 +13,7 @@ import getTournament from "../../../functions/tournamentFunctions/getTournament"
 import channelID from "../../../functions/channelID";
 import { discordStringTimestamp, parseDateOrTimestamp } from "../../../../Server/utils/dateParse";
 import { ScoringMethod, StageType } from "../../../../Interfaces/stage";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))
@@ -270,13 +271,13 @@ async function stageDone (m: Message | ChatInputCommandInteraction, stage: Stage
             { name: "# of Rounds", value: stage.rounds.length.toString(), inline: true },
             { name: "Initial → Final Team Count", value: stage.initialSize + " → " + stage.finalSize, inline: true }
         )
-        .setTimestamp(new Date())
-        .setAuthor({ name: commandUser(m).username, iconURL: (m.member as GuildMember | null)?.displayAvatarURL() ?? undefined });
+        .setTimestamp()
+        .setAuthor({ name: commandUser(m).username, icon_url: (m.member as GuildMember | null)?.displayAvatarURL() ?? undefined });
 
     if (stage.stageType === StageType.Qualifiers)
         embed.addFields({ name: "Team Qualifier Choose Order", value: stage.qualifierTeamChooseOrder ? "Yes" : "No", inline: true });
 
-    await m.channel!.send({ embeds: [embed] });
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/stage/edit.ts
+++ b/DiscordBot/commands/tournaments/stage/edit.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, PermissionFlagsBits, PermissionsBitField, SlashCommandBuilder } from "discord.js";
 import { Command } from "../../index";
 import respond from "../../../functions/respond";
 import channelID from "../../../functions/channelID";
@@ -13,6 +13,7 @@ import editProperty from "../../../functions/tournamentFunctions/editProperty";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
 import { discordStringTimestamp, parseDateOrTimestamp } from "../../../../Server/utils/dateParse";
 import { ScoringMethod, StageType } from "../../../../Interfaces/stage";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))
@@ -294,13 +295,13 @@ async function stageSave (m: Message, stage: Stage) {
             { name: "# of Rounds", value: stage.rounds.length.toString(), inline: true },
             { name: "Initial → Final Team Count", value: stage.initialSize + " → " + stage.finalSize, inline: true }
         )
-        .setTimestamp(new Date())
-        .setAuthor({ name: commandUser(m).username, iconURL: (m.member )?.displayAvatarURL() ?? undefined });
+        .setTimestamp()
+        .setAuthor({ name: commandUser(m).username, icon_url: m.member?.displayAvatarURL() ?? undefined });
 
     if (stage.stageType === StageType.Qualifiers)
         embed.addFields({ name: "Team Qualifier Choose Order", value: stage.qualifierTeamChooseOrder ? "Yes" : "No", inline: true });
 
-    await m.channel.send({ embeds: [ embed ] });
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/stage/edit.ts
+++ b/DiscordBot/commands/tournaments/stage/edit.ts
@@ -13,7 +13,7 @@ import editProperty from "../../../functions/tournamentFunctions/editProperty";
 import { profanityFilterStrong } from "../../../../Interfaces/comment";
 import { discordStringTimestamp, parseDateOrTimestamp } from "../../../../Server/utils/dateParse";
 import { ScoringMethod, StageType } from "../../../../Interfaces/stage";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (!m.guild || !(m.member!.permissions as Readonly<PermissionsBitField>).has(PermissionFlagsBits.Administrator))

--- a/DiscordBot/commands/tournaments/stage/info.ts
+++ b/DiscordBot/commands/tournaments/stage/info.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from "discord.js";
 import { Command } from "../../index";
 import respond from "../../../functions/respond";
 import channelID from "../../../functions/channelID";
@@ -12,6 +12,7 @@ import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { Mappool } from "../../../../Models/tournaments/mappools/mappool";
 import { Round } from "../../../../Models/tournaments/round";
 import { extractParameter } from "../../../functions/parameterFunctions";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -69,7 +70,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
         );
 
     // Send the embed
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/stage/info.ts
+++ b/DiscordBot/commands/tournaments/stage/info.ts
@@ -12,7 +12,7 @@ import { discordStringTimestamp } from "../../../../Server/utils/dateParse";
 import { Mappool } from "../../../../Models/tournaments/mappools/mappool";
 import { Round } from "../../../../Models/tournaments/round";
 import { extractParameter } from "../../../functions/parameterFunctions";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/team/invite/list.ts
+++ b/DiscordBot/commands/tournaments/team/invite/list.ts
@@ -5,7 +5,7 @@ import respond from "../../../../functions/respond";
 import getTeamInvites from "../../../../../Server/functions/get/getTeamInvites";
 import getUser from "../../../../../Server/functions/get/getUser";
 import { loginResponse } from "../../../../functions/loginResponse";
-import { EmbedBuilder } from "../../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/team/invite/list.ts
+++ b/DiscordBot/commands/tournaments/team/invite/list.ts
@@ -1,10 +1,11 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from "discord.js";
 import { Command } from "../../../";
 import commandUser from "../../../../functions/commandUser";
 import respond from "../../../../functions/respond";
 import getTeamInvites from "../../../../../Server/functions/get/getTeamInvites";
 import getUser from "../../../../../Server/functions/get/getUser";
 import { loginResponse } from "../../../../functions/loginResponse";
+import { EmbedBuilder } from "../../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -21,14 +22,14 @@ async function run (m: Message | ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
         .setTitle("Team Invites")
         .setDescription(`Showing ${invites.length} invites`)
-        .setFields(invites.map(invite => {
+        .addFields(invites.map(invite => {
             return {
                 name: `${invite.team.name} (${invite.team.abbreviation})`,
                 value: `Manager: ${invite.team.manager.osu.username} <@${invite.team.manager.discord.userID}> (${invite.team.manager.osu.userID})`,
             };
         }));
 
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/team/list.ts
+++ b/DiscordBot/commands/tournaments/team/list.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from "discord.js";
 import { Command } from "../../";
 import { extractParameters } from "../../../functions/parameterFunctions";
 import { Team } from "../../../../Models/tournaments/team";
@@ -6,6 +6,7 @@ import commandUser from "../../../functions/commandUser";
 import respond from "../../../functions/respond";
 import getUser from "../../../../Server/functions/get/getUser";
 import { loginResponse } from "../../../functions/loginResponse";
+import { EmbedBuilder } from "../../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -43,14 +44,14 @@ async function run (m: Message | ChatInputCommandInteraction) {
     const embed = new EmbedBuilder()
         .setTitle("Teams")
         .setDescription(`Showing ${teams.length} teams`)
-        .setFields(teams.map(team => {
+        .addFields(teams.map(team => {
             return {
                 name: `${team.name} (${team.abbreviation})`,
                 value: `Manager: ${team.manager.osu.username} <@${team.manager.discord.userID}> (${team.manager.osu.userID})\nMembers: ${team.members.map(member => `${member.osu.username} <@${member.discord.userID}> (${member.osu.userID})`).join(", ")}\nTournaments: ${team.tournaments.map(tournament => `${tournament.name} (${tournament.abbreviation})`).join(", ")}`,
             };
         }));
 
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/tournaments/team/list.ts
+++ b/DiscordBot/commands/tournaments/team/list.ts
@@ -6,7 +6,7 @@ import commandUser from "../../../functions/commandUser";
 import respond from "../../../functions/respond";
 import getUser from "../../../../Server/functions/get/getUser";
 import { loginResponse } from "../../../functions/loginResponse";
-import { EmbedBuilder } from "../../../functions/embedHandlers";
+import { EmbedBuilder } from "../../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/teams.ts
+++ b/DiscordBot/commands/tournaments/teams.ts
@@ -5,7 +5,7 @@ import { extractParameter } from "../../functions/parameterFunctions";
 import getTournament from "../../functions/tournamentFunctions/getTournament";
 import channelID from "../../functions/channelID";
 import respond from "../../functions/respond";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)

--- a/DiscordBot/commands/tournaments/teams.ts
+++ b/DiscordBot/commands/tournaments/teams.ts
@@ -1,10 +1,11 @@
-import { ChatInputCommandInteraction, EmbedBuilder, Message, SlashCommandBuilder } from "discord.js";
+import { ChatInputCommandInteraction, Message, SlashCommandBuilder } from "discord.js";
 import { Command } from "..";
 import { Team } from "../../../Models/tournaments/team";
 import { extractParameter } from "../../functions/parameterFunctions";
 import getTournament from "../../functions/tournamentFunctions/getTournament";
 import channelID from "../../functions/channelID";
 import respond from "../../functions/respond";
+import { EmbedBuilder } from "../../functions/embedHandlers";
 
 async function run (m: Message | ChatInputCommandInteraction) {
     if (m instanceof ChatInputCommandInteraction)
@@ -32,10 +33,10 @@ async function run (m: Message | ChatInputCommandInteraction) {
             }).join("\n\n"))
         .setFooter({
             text: `Requested by ${m instanceof Message ? m.author.username : m.user.username}`,
-            iconURL: (m instanceof Message ? m.author.avatarURL() : m.user.avatarURL()) ?? undefined,
+            icon_url: (m instanceof Message ? m.author.avatarURL() : m.user.avatarURL()) ?? undefined,
         });
 
-    await respond(m, undefined, [ embed ]);
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commands/utility/help.ts
+++ b/DiscordBot/commands/utility/help.ts
@@ -1,6 +1,6 @@
 import { Message, ChatInputCommandInteraction, SlashCommandBuilder, APIApplicationCommandOption, GuildMember, ApplicationCommandOptionType } from "discord.js";
 import { Command, commands } from "..";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 import respond from "../../functions/respond";
 
 function optionParser (options: APIApplicationCommandOption[] | undefined): string {

--- a/DiscordBot/commands/utility/help.ts
+++ b/DiscordBot/commands/utility/help.ts
@@ -1,5 +1,7 @@
-import { Message, EmbedBuilder, ChatInputCommandInteraction, SlashCommandBuilder, APIApplicationCommandOption, GuildMember, ApplicationCommandOptionType } from "discord.js";
+import { Message, ChatInputCommandInteraction, SlashCommandBuilder, APIApplicationCommandOption, GuildMember, ApplicationCommandOptionType } from "discord.js";
 import { Command, commands } from "..";
+import { EmbedBuilder } from "../../functions/embedHandlers";
+import respond from "../../functions/respond";
 
 function optionParser (options: APIApplicationCommandOption[] | undefined): string {
     if (!options) return "";
@@ -63,24 +65,23 @@ function optionParser (options: APIApplicationCommandOption[] | undefined): stri
 
 async function run (m: Message | ChatInputCommandInteraction) {
     const helpRegex = /help\s+(.+)/i; // General command
-    const embed = new EmbedBuilder({
-        author: {
+    const embed = new EmbedBuilder()
+        .setAuthor({
             //name: "Click here to invite Corsace!", <-- Add later when bot is public
             //url: `https://discordapp.com/oauth2/authorize?&client_id=${config.discord.clientId}&scope=bot&permissions=0`
             name: "corsace",
-            iconURL: (m.member as GuildMember | null)?.displayAvatarURL() ?? undefined,
-        },
-        description: "**Most commands have other forms as well for convenience!**\n\n**Do `!help <command>` for more information about the command!**\nHelp information format: `(cmd|names) <args> [optional args]`\n\nWrap args around in quotes if they have spaces within them.\n**Example:** `\"2024-01-01 3:00:00\"`",
-        color: 0xFB2475,
-        fields: [{
+            icon_url: (m.member as GuildMember | null)?.displayAvatarURL() ?? undefined,
+        })
+        .setDescription("**Most commands have other forms as well for convenience!**\n\n**Do `!help <command>` for more information about the command!**\nHelp information format: `(cmd|names) <args> [optional args]`\n\nWrap args around in quotes if they have spaces within them.\n**Example:** `\"2024-01-01 3:00:00\"`")
+        .setColor(0xFB2475)
+        .addField({
             name: "categories:",
             value: commands.filter((v, i, s) => s.findIndex(c => c.category === v.category) === i).map(c => `\`${c.category}\``).join("\n"),
-        }],
-    });
+        });
 
     const arg = m instanceof Message ? helpRegex.exec(m.content)?.[1] : m.options.getString("command", false);
     if (!arg) {
-        await m.reply({ embeds: [embed] });
+        await respond(m, undefined, embed);
         return;
     }
 
@@ -105,7 +106,7 @@ async function run (m: Message | ChatInputCommandInteraction) {
         }));
     }
 
-    await m.reply({ embeds: [embed] });
+    await respond(m, undefined, embed);
 }
 
 const data = new SlashCommandBuilder()

--- a/DiscordBot/commandsInexplicit/osu/osuTimestamp.ts
+++ b/DiscordBot/commandsInexplicit/osu/osuTimestamp.ts
@@ -1,6 +1,6 @@
 import { Message } from "discord.js";
 import { config } from "node-config-ts";
-import { EmbedBuilder } from "../../functions/embedHandlers";
+import { EmbedBuilder } from "../../functions/embedBuilder";
 import respond from "../../functions/respond";
 
 export default async function osuTimestamp (m: Message) {

--- a/DiscordBot/commandsInexplicit/osu/osuTimestamp.ts
+++ b/DiscordBot/commandsInexplicit/osu/osuTimestamp.ts
@@ -1,5 +1,7 @@
-import { EmbedBuilder, Message } from "discord.js";
+import { Message } from "discord.js";
 import { config } from "node-config-ts";
+import { EmbedBuilder } from "../../functions/embedHandlers";
+import respond from "../../functions/respond";
 
 export default async function osuTimestamp (m: Message) {
     const timestampRegex = /(\d+):(\d{2}):(\d{3})\s*(\(((\d,?)+)\))?/gmi;
@@ -26,16 +28,15 @@ export default async function osuTimestamp (m: Message) {
 
     const splits = description.split("\n").reduce((acc: string[], line: string) => {
         const last = acc[acc.length - 1];
-        if (last && (last + line).length <= 4096) {
+        if (last && (last + line).length <= 4096)
             acc[acc.length - 1] += line + "\n";
-        } else {
+        else
             acc.push(line + "\n");
-        }
         return acc;
     }, []);
 
     for (const desc of splits) {
         embed.setDescription(desc);
-        await m.channel.send({ embeds: [embed] });
+        await respond(m, undefined, embed);
     }
 }

--- a/DiscordBot/functions/beatmapEmbed.ts
+++ b/DiscordBot/functions/beatmapEmbed.ts
@@ -5,7 +5,7 @@ import { discordGuild } from "../../Server/discord";
 import { osuClient } from "../../Server/osu";
 import modeColour from "./modeColour";
 import ppCalculator from "./ppCalculator";
-import { EmbedBuilder } from "./embedHandlers";
+import { EmbedBuilder } from "./embedBuilder";
 
 // TODO: Implement isRecent and remove the eslint disable rule
 export default async function beatmapEmbed (beatmap: Beatmap, mods: string, user: User, missCount?: number, userScore?: UserScore, isRecent?: boolean): Promise<EmbedBuilder>;

--- a/DiscordBot/functions/beatmapEmbed.ts
+++ b/DiscordBot/functions/beatmapEmbed.ts
@@ -1,4 +1,3 @@
-import { EmbedBuilder, EmbedData } from "discord.js";
 import { ApprovalStatus, Beatmap, BeatmapScore, Mode, Score, UserScore } from "nodesu";
 import { acronymtoMods, modsToAcronym } from "../../Interfaces/mods";
 import { User } from "../../Models/user";
@@ -6,6 +5,7 @@ import { discordGuild } from "../../Server/discord";
 import { osuClient } from "../../Server/osu";
 import modeColour from "./modeColour";
 import ppCalculator from "./ppCalculator";
+import { EmbedBuilder } from "./embedHandlers";
 
 // TODO: Implement isRecent and remove the eslint disable rule
 export default async function beatmapEmbed (beatmap: Beatmap, mods: string, user: User, missCount?: number, userScore?: UserScore, isRecent?: boolean): Promise<EmbedBuilder>;
@@ -13,7 +13,7 @@ export default async function beatmapEmbed (beatmap: Beatmap, mods: string, set:
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default async function beatmapEmbed (beatmap: Beatmap, mods: string, setorUser: Beatmap[] | User, missCount?: number, userScore?: UserScore, isRecent?: boolean): Promise<EmbedBuilder> {
 
-    const embedMsg = defaultBeatmapEmbed(beatmap, setorUser instanceof User ? false : true);
+    let embed = defaultBeatmapEmbed(beatmap, setorUser instanceof User ? false : true);
 
     const totalHits = beatmap.countNormal + beatmap.countSlider + beatmap.countSpinner;
 
@@ -85,17 +85,19 @@ export default async function beatmapEmbed (beatmap: Beatmap, mods: string, seto
             pp = `**${score.pp.toFixed(2)}pp**/${ppCalculator(beatmap, FCVersion).toFixed(2)}pp `;
         }
 
-        embedMsg.title = `${beatmap.artist} - ${beatmap.title} [${beatmap.version}] by ${beatmap.creator}`;
-        embedMsg.url = `https://osu.ppy.sh/beatmaps/${beatmap.id}`;
-        embedMsg.author = {
-            url: `https://osu.ppy.sh/users/${user.osu.userID}`,
-            name: user.osu.username,
-            iconURL: `${user.osu.avatar}`,
-        };
-        embedMsg.description += "\n" + 
-            scoreRank + scorePrint + scoreMod + combo + acc + replay + "\n" +
-            mapCompletion + "\n" +
-            pp + hits + "\n" + "\n";
+        embed = embed
+            .setTitle(`${beatmap.artist} - ${beatmap.title} [${beatmap.version}] by ${beatmap.creator}`)
+            .setDescription(embed.embed.description + "\n" + 
+                scoreRank + scorePrint + scoreMod + combo + acc + replay + "\n" +
+                mapCompletion + "\n" +
+                pp + hits + "\n" + "\n"
+            )
+            .setURL(`https://osu.ppy.sh/beatmaps/${beatmap.beatmapId}`)
+            .setAuthor({
+                url: `https://osu.ppy.sh/users/${user.osu.userID}`,
+                name: user.osu.username,
+                icon_url: `${user.osu.avatar}`,
+            });
     } else {
         // Get extra beatmap information
         const set = setorUser;
@@ -158,25 +160,28 @@ export default async function beatmapEmbed (beatmap: Beatmap, mods: string, seto
         const ppTextHeader = `**[${beatmap.version}]** with mods: **${mods}**`;
         const ppText = `**100%:** ${Math.floor(ppCalculator(beatmap, score100))}pp | **99%:** ${Math.floor(ppCalculator(beatmap, score99))}pp | **98%:** ${Math.floor(ppCalculator(beatmap, score98))}pp | **97%:** ${Math.floor(ppCalculator(beatmap, score97))}pp | **95%:** ${Math.floor(ppCalculator(beatmap, score95))}pp`;
 
-        embedMsg.author = {
-            url: `https://osu.ppy.sh/beatmaps/${beatmap.beatmapId}`,
-            name: `${beatmap.artist} - ${beatmap.title} by ${beatmap.creator}`,
-            iconURL: `https://a.ppy.sh/${beatmap.creatorId}`,
-        };
-        embedMsg.description += status + "\n" +
-            download + "\n" +
-            diffs + "\n" + "\n" +
-            ppTextHeader + "\n" +
-            ppText;
-        embedMsg.footer = {
-            text: `Corsace | https://corsace.io`,
-        };
+        embed = embed
+            .setAuthor({
+                name: `${beatmap.artist} - ${beatmap.title} by ${beatmap.creator}`,
+                icon_url: `https://a.ppy.sh/${beatmap.creatorId}`,
+                url: `https://osu.ppy.sh/beatmaps/${beatmap.beatmapId}`,
+            })
+            .setDescription(embed.embed.description +
+                status + "\n" +
+                download + "\n" +
+                diffs + "\n" + "\n" +
+                ppTextHeader + "\n" +
+                ppText
+            )
+            .setFooter({
+                text: `Corsace | https://corsace.io`,
+            });
     }
 
-    return new EmbedBuilder(embedMsg);
+    return embed;
 }
 
-function defaultBeatmapEmbed (beatmap: Beatmap, addFC: boolean): EmbedData {
+function defaultBeatmapEmbed (beatmap: Beatmap, addFC: boolean): EmbedBuilder {
     // Obtain beatmap information
     const totalMinutes = Math.floor(beatmap.totalLength / 60);
     let totalSeconds = `${Math.round(beatmap.totalLength % 60)}`;
@@ -196,14 +201,11 @@ function defaultBeatmapEmbed (beatmap: Beatmap, addFC: boolean): EmbedData {
     const mapStats = `**CS:** ${beatmap.CS.toFixed(2)} **AR:** ${beatmap.AR.toFixed(2)} **OD:** ${beatmap.OD.toFixed(2)} **HP:** ${beatmap.HP.toFixed(2)}`;
     const mapObjs = `**Circles:** ${beatmap.countNormal} **Sliders:** ${beatmap.countSlider} **Spinners:** ${beatmap.countSpinner}`;
 
-    return {
-        description: sr + "\n" +
+    return new EmbedBuilder()
+        .setDescription(sr + "\n" +
 			length + bpm + combo + "\n" +
 			mapStats + "\n" +
-			mapObjs + "\n",
-        color: modeColour(beatmap.mode),
-        thumbnail: {
-            url: `https://b.ppy.sh/thumb/${beatmap.beatmapSetId}l.jpg`,
-        },
-    };
+			mapObjs + "\n")
+        .setColor(modeColour(beatmap.mode))
+        .setThumbnail(`https://b.ppy.sh/thumb/${beatmap.beatmapSetId}l.jpg`);
 }

--- a/DiscordBot/functions/beatmapParse.ts
+++ b/DiscordBot/functions/beatmapParse.ts
@@ -2,7 +2,6 @@
 import axios from "axios";
 import { Entry, Parse } from "unzipper";
 import { ChatInputCommandInteraction, ForumChannel, Message } from "discord.js";
-import { Beatmap as APIBeatmap} from "nodesu";
 import { CustomBeatmap } from "../../Models/tournaments/mappools/customBeatmap";
 import { deletePack } from "../../Server/functions/tournaments/mappool/mappackFunctions";
 import { MappoolMapHistory } from "../../Models/tournaments/mappools/mappoolMapHistory";
@@ -17,6 +16,7 @@ import { Mappool } from "../../Models/tournaments/mappools/mappool";
 import { MappoolSlot } from "../../Models/tournaments/mappools/mappoolSlot";
 import { User } from "../../Models/user";
 import { discordClient } from "../../Server/discord";
+import customBeatmapToNodesu from "../../Server/functions/tournaments/mappool/customBeatmapToNodesu";
 import { ParserBeatmap, parseBeatmap,  parseBeatmapAttributes, ParserBeatmapAttributes, parseBeatmapStrains, ParserStrains } from "wasm-replay-parser-rs";
 
 export async function beatmapParse (m: Message | ChatInputCommandInteraction, diff: string, link: string, mods = 0) {
@@ -169,68 +169,8 @@ export async function parsedBeatmapToCustom (
     log.link = link;
     await log.save();
 
-    const apiBeatmap = new APIBeatmap({
-        "beatmapset_id": "-1",
-        "beatmap_id": "-1",
-        "approved": "-3",
-        "total_length": `${mappoolMap.customBeatmap.totalLength}`,
-        "hit_length": `${mappoolMap.customBeatmap.hitLength}`,
-        "version": mappoolMap.customBeatmap.difficulty,
-        "file_md5": "",
-        "diff_size": `${mappoolMap.customBeatmap.circleSize}`,
-        "diff_overall": `${mappoolMap.customBeatmap.overallDifficulty}`,
-        "diff_approach": `${mappoolMap.customBeatmap.approachRate}`,
-        "diff_drain": `${mappoolMap.customBeatmap.hpDrain}`,
-        "mode": `${mappoolMap.customBeatmap.mode.ID - 1}`,
-        "count_normal": `${mappoolMap.customBeatmap.circles}`,
-        "count_slider": `${mappoolMap.customBeatmap.sliders}`,
-        "count_spinner": `${mappoolMap.customBeatmap.spinners}`,
-        "submit_date": [
-            mappoolMap.createdAt.getUTCMonth() + 1,
-            mappoolMap.createdAt.getUTCDate(),
-            mappoolMap.createdAt.getUTCFullYear(),
-        ].join("/") + " " + [
-            mappoolMap.createdAt.getUTCHours(),
-            mappoolMap.createdAt.getUTCMinutes(),
-            mappoolMap.createdAt.getUTCSeconds(),
-        ].join(":"),
-        "approved_date": null,
-        "last_update": [
-            mappoolMap.lastUpdate.getUTCMonth() + 1,
-            mappoolMap.lastUpdate.getUTCDate(),
-            mappoolMap.lastUpdate.getUTCFullYear(),
-        ].join("/") + " " + [
-            mappoolMap.lastUpdate.getUTCHours(),
-            mappoolMap.lastUpdate.getUTCMinutes(),
-            mappoolMap.lastUpdate.getUTCSeconds(),
-        ].join(":"),
-        "artist": mappoolMap.customBeatmap.artist,
-        "artist_unicode": mappoolMap.customBeatmap.artist,
-        "title": mappoolMap.customBeatmap.title,
-        "title_unicode": mappoolMap.customBeatmap.title,
-        "creator": mappoolMap.customMappers.map(u => u.osu.username).join(", "),
-        "creator_id": "-1",
-        "bpm": `${mappoolMap.customBeatmap.BPM}`,
-        "source": "",
-        "tags": `${mappoolMap.customBeatmap.link ?? ""}`,
-        "genre_id": "0",
-        "language_id": "0",
-        "favourite_count": "0",
-        "rating": "0",
-        "storyboard": "0",
-        "video": "0",
-        "download_unavailable": "0",
-        "audio_unavailable": "0",
-        "playcount": "0",
-        "passcount": "0",
-        "packs": null,
-        "max_combo": mappoolMap.customBeatmap.maxCombo ? `${mappoolMap.customBeatmap.maxCombo}` : null,
-        "diff_aim": mappoolMap.customBeatmap.aimSR ? `${mappoolMap.customBeatmap.aimSR}` : null,
-        "diff_speed": mappoolMap.customBeatmap.speedSR ? `${mappoolMap.customBeatmap.speedSR}` : null,
-        "difficultyrating": `${mappoolMap.customBeatmap.totalSR}`,
-    });
-    const set = [apiBeatmap];
-    const mappoolMapEmbed = await beatmapEmbed(applyMods(apiBeatmap, modsToAcronym(slot.allowedMods ?? 0)), modsToAcronym(slot.allowedMods ?? 0), set);
+    const nodesuBeatmap = customBeatmapToNodesu({...mappoolMap, customBeatmap: mappoolMap.customBeatmap});
+    const mappoolMapEmbed = await beatmapEmbed(applyMods(nodesuBeatmap, modsToAcronym(slot.allowedMods ?? 0)), modsToAcronym(slot.allowedMods ?? 0), [nodesuBeatmap]);
     mappoolMapEmbed.data.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.data.author!.name}`;
 
     await respond(m, `Submitted \`${artist} - ${title} [${diff}]\` to \`${mappoolSlot}\``, [mappoolMapEmbed]);

--- a/DiscordBot/functions/beatmapParse.ts
+++ b/DiscordBot/functions/beatmapParse.ts
@@ -171,9 +171,9 @@ export async function parsedBeatmapToCustom (
 
     const nodesuBeatmap = customBeatmapToNodesu({...mappoolMap, customBeatmap: mappoolMap.customBeatmap});
     const mappoolMapEmbed = await beatmapEmbed(applyMods(nodesuBeatmap, modsToAcronym(slot.allowedMods ?? 0)), modsToAcronym(slot.allowedMods ?? 0), [nodesuBeatmap]);
-    mappoolMapEmbed.data.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.data.author!.name}`;
+    mappoolMapEmbed.embed.author!.name = `${mappoolSlot}: ${mappoolMapEmbed.embed.author!.name}`;
 
-    await respond(m, `Submitted \`${artist} - ${title} [${diff}]\` to \`${mappoolSlot}\``, [mappoolMapEmbed]);
+    await respond(m, `Submitted \`${artist} - ${title} [${diff}]\` to \`${mappoolSlot}\``, mappoolMapEmbed);
 
     await mappoolLog(tournament, "submit", user, log, mappoolSlot);
 }

--- a/DiscordBot/functions/embedBuilder.ts
+++ b/DiscordBot/functions/embedBuilder.ts
@@ -1,10 +1,5 @@
-import { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter, JSONEncodable, RestOrArray } from "discord.js";
+import { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter, RestOrArray } from "discord.js";
 import truncate from "../../Server/utils/truncate";
-
-export interface EmbedPage {
-    description: string;
-    fields: APIEmbedField[];
-}
 
 export class EmbedBuilder {
     public embed: APIEmbed;
@@ -143,38 +138,4 @@ export class EmbedBuilder {
             count += embed.fields.reduce((acc, f) => acc + f.name.length + f.value.length, 0);
         return count;
     }
-}
-
-export function enforceEmbedLimits (embed: APIEmbed | JSONEncodable<APIEmbed>): APIEmbed | JSONEncodable<APIEmbed> {
-    if ("title" in embed && embed.title)
-        embed.title = truncate(embed.title, 256);
-    if ("description" in embed && embed.description)
-        embed.description = truncate(embed.description, 2048);
-    if ("footer" in embed && embed.footer?.text)
-        embed.footer.text = truncate(embed.footer.text, 2048);
-    if ("author" in embed && embed.author?.name)
-        embed.author.name = truncate(embed.author.name, 256);
-    if ("fields" in embed && embed.fields)
-        embed.fields = embed.fields.map(f => ({
-            name: f.name.length > 0 ? truncate(f.name, 256) : "No Name",
-            value: f.value.length > 0 ? truncate(f.value, 1024) : "No Value",
-            inline: f.inline,
-        }));
-    return embed;
-}
-
-export function paginateEmbed (embed: APIEmbed | JSONEncodable<APIEmbed>): EmbedPage[] {
-    const pages: EmbedPage[] = [];
-    let description = "description" in embed && embed.description ? embed.description : "";
-    let fields = "fields" in embed && embed.fields ? embed.fields : [];
-    while (description.length > 0 || fields.length > 0) {
-        // Remove upto 2048 characters from the description, and upto 25 fields from the fields array into a new page
-        pages.push({
-            description: description.length > 0 ? description.slice(0, 2048) : pages.length === 0 ? "" : pages[pages.length - 1].description,
-            fields: fields.length > 0 ? fields.splice(0, 25) : pages.length === 0 ? [] : pages[pages.length - 1].fields,
-        });
-        description = description.length > 2048 ? description.slice(2048) : "";
-        fields = fields.length > 25 ? fields.splice(25) : [];
-    }
-    return pages;
 }

--- a/DiscordBot/functions/embedHandlers.ts
+++ b/DiscordBot/functions/embedHandlers.ts
@@ -23,12 +23,21 @@ export class EmbedBuilder {
         return this;
     }
 
+    public setURL (url: string) {
+        try {
+            this.embed.url = new URL(url).toString();
+        } catch {
+            this.embed.url = undefined;
+        }
+        return this;
+    }
+
     public setColor (color: number) {
         this.embed.color = color;
         return this;
     }
 
-    public setTimestamp (timestamp: Date) {
+    public setTimestamp (timestamp: Date = new Date()) {
         // ISO 8601 format string according to https://discord.com/developers/docs/resources/channel#embed-object-embed-structure
         this.embed.timestamp = timestamp.toISOString();
         return this;

--- a/DiscordBot/functions/embedHandlers.ts
+++ b/DiscordBot/functions/embedHandlers.ts
@@ -1,9 +1,139 @@
-import { APIEmbed, APIEmbedField, JSONEncodable } from "discord.js";
+import { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter, JSONEncodable } from "discord.js";
 import truncate from "../../Server/utils/truncate";
 
 export interface EmbedPage {
     description: string;
     fields: APIEmbedField[];
+}
+
+export class EmbedBuilder {
+    public embed: APIEmbed;
+
+    constructor () {
+        this.embed = {};
+    }
+
+    public setTitle (title: string) {
+        this.embed.title = truncate(title, 256);
+        return this;
+    }
+
+    public setDescription (description: string) {
+        this.embed.description = truncate(description, 4096);
+        return this;
+    }
+
+    public setColor (color: number) {
+        this.embed.color = color;
+        return this;
+    }
+
+    public setTimestamp (timestamp: Date) {
+        // ISO 8601 format string according to https://discord.com/developers/docs/resources/channel#embed-object-embed-structure
+        this.embed.timestamp = timestamp.toISOString();
+        return this;
+    }
+
+    public setFooter ({ icon_url, text }: APIEmbedFooter) {
+        this.embed.footer = { icon_url, text: truncate(text, 2048) };
+        return this;
+    }
+
+    public setThumbnail (url: string) {
+        try {
+            this.embed.thumbnail = { url: new URL(url).toString() };
+        } catch {
+            this.embed.thumbnail = undefined;
+        }
+        return this;
+    }
+
+    public setImage (url: string) {
+        try {
+            this.embed.image = { url: new URL(url).toString() };
+        } catch {
+            this.embed.image = undefined;
+        }
+        return this;
+    }
+
+    public setAuthor ({ name, url, icon_url }: APIEmbedAuthor) {
+        this.embed.author = { name: truncate(name, 256), url, icon_url };
+        return this;
+    }
+
+    public addField ({ name, value, inline }: APIEmbedField) {
+        if (!this.embed.fields)
+            this.embed.fields = [];
+        this.embed.fields.push({ name: truncate(name, 256), value: truncate(value, 1024), inline });
+        return this;
+    }
+
+    public addFields (fields: APIEmbedField[]) {
+        if (!this.embed.fields)
+            this.embed.fields = [];
+        this.embed.fields.push(...fields.map(f => ({
+            name: truncate(f.name, 256),
+            value: truncate(f.value, 1024),
+            inline: f.inline,
+        })));
+        return this;
+    }
+
+    public build () {
+        const pages: APIEmbed[] = [];
+        let embedDescription = this.embed.description ?? "\u200b";
+        let embedFields = this.embed.fields ?? [];
+        pages.push({
+            ...this.embed,
+            description: embedDescription.length > 4096 ? embedDescription.slice(0, 4096) : embedDescription,
+            fields: embedFields.length > 25 ? embedFields.slice(0, 25) : embedFields,
+        });
+        while (embedDescription.length > 4096 || embedFields.length > 25) {
+            embedDescription = embedDescription.length > 4096 ? embedDescription.slice(4096) : pages[pages.length - 1].description ?? "";
+            embedFields = embedFields.length > 25 ? embedFields.slice(25) : pages[pages.length - 1].fields ?? [];
+
+            const description = embedDescription.length > 4096 ? embedDescription.slice(0, 4096) : embedDescription;
+            const fields = embedFields.length > 25 ? embedFields.slice(0, 25) : embedFields;
+            pages.push({
+                ...this.embed,
+                description,
+                fields,
+            });
+        }
+
+        pages.map(e => {
+            while (this.characterCount(e) > 6000) {
+                if (e.description)
+                    e.description = e.description.length > 3 ? truncate(e.description, e.description.length - 3) : "\u200b";
+                if (e.fields)
+                    e.fields = e.fields.map(f => ({
+                        name: f.name.length > 3 ? truncate(f.name, f.name.length - 3) : "\u200b",
+                        value: f.value.length > 3 ? truncate(f.value, f.value.length - 3) : "\u200b",
+                        inline: f.inline,
+                    }));
+            }
+
+            return e;
+        });
+
+        return pages;
+    }
+
+    private characterCount (embed: APIEmbed = this.embed) {
+        let count = 0;
+        if (embed.title)
+            count += embed.title.length;
+        if (embed.description)
+            count += embed.description.length;
+        if (embed.footer?.text)
+            count += embed.footer.text.length;
+        if (embed.author?.name)
+            count += embed.author.name.length;
+        if (embed.fields)
+            count += embed.fields.reduce((acc, f) => acc + f.name.length + f.value.length, 0);
+        return count;
+    }
 }
 
 export function enforceEmbedLimits (embed: APIEmbed | JSONEncodable<APIEmbed>): APIEmbed | JSONEncodable<APIEmbed> {

--- a/DiscordBot/functions/embedHandlers.ts
+++ b/DiscordBot/functions/embedHandlers.ts
@@ -1,4 +1,4 @@
-import { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter, JSONEncodable } from "discord.js";
+import { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter, JSONEncodable, RestOrArray } from "discord.js";
 import truncate from "../../Server/utils/truncate";
 
 export interface EmbedPage {
@@ -69,10 +69,10 @@ export class EmbedBuilder {
         return this;
     }
 
-    public addFields (fields: APIEmbedField[]) {
+    public addFields (...fields: RestOrArray<APIEmbedField>) {
         if (!this.embed.fields)
             this.embed.fields = [];
-        this.embed.fields.push(...fields.map(f => ({
+        this.embed.fields.push(...fields.flat().map(f => ({
             name: truncate(f.name, 256),
             value: truncate(f.value, 1024),
             inline: f.inline,

--- a/DiscordBot/functions/embedHandlers.ts
+++ b/DiscordBot/functions/embedHandlers.ts
@@ -1,0 +1,41 @@
+import { APIEmbed, APIEmbedField, JSONEncodable } from "discord.js";
+import truncate from "../../Server/utils/truncate";
+
+export interface EmbedPage {
+    description: string;
+    fields: APIEmbedField[];
+}
+
+export function enforceEmbedLimits (embed: APIEmbed | JSONEncodable<APIEmbed>): APIEmbed | JSONEncodable<APIEmbed> {
+    if ("title" in embed && embed.title)
+        embed.title = truncate(embed.title, 256);
+    if ("description" in embed && embed.description)
+        embed.description = truncate(embed.description, 2048);
+    if ("footer" in embed && embed.footer?.text)
+        embed.footer.text = truncate(embed.footer.text, 2048);
+    if ("author" in embed && embed.author?.name)
+        embed.author.name = truncate(embed.author.name, 256);
+    if ("fields" in embed && embed.fields)
+        embed.fields = embed.fields.map(f => ({
+            name: f.name.length > 0 ? truncate(f.name, 256) : "No Name",
+            value: f.value.length > 0 ? truncate(f.value, 1024) : "No Value",
+            inline: f.inline,
+        }));
+    return embed;
+}
+
+export function paginateEmbed (embed: APIEmbed | JSONEncodable<APIEmbed>): EmbedPage[] {
+    const pages: EmbedPage[] = [];
+    let description = "description" in embed && embed.description ? embed.description : "";
+    let fields = "fields" in embed && embed.fields ? embed.fields : [];
+    while (description.length > 0 || fields.length > 0) {
+        // Remove upto 2048 characters from the description, and upto 25 fields from the fields array into a new page
+        pages.push({
+            description: description.length > 0 ? description.slice(0, 2048) : pages.length === 0 ? "" : pages[pages.length - 1].description,
+            fields: fields.length > 0 ? fields.splice(0, 25) : pages.length === 0 ? [] : pages[pages.length - 1].fields,
+        });
+        description = description.length > 2048 ? description.slice(2048) : "";
+        fields = fields.length > 25 ? fields.splice(25) : [];
+    }
+    return pages;
+}

--- a/DiscordBot/functions/respond.ts
+++ b/DiscordBot/functions/respond.ts
@@ -1,12 +1,76 @@
-import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, AttachmentPayload, ChatInputCommandInteraction, JSONEncodable, Message } from "discord.js";
+import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, ActionRowBuilder, AttachmentPayload, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, ComponentType, JSONEncodable, Message } from "discord.js";
+import { EmbedPage, enforceEmbedLimits, paginateEmbed } from "./embedHandlers";
+import commandUser from "./commandUser";
 
 export default async function respond (m: Message | ChatInputCommandInteraction, content?: string, embeds?: (APIEmbed | JSONEncodable<APIEmbed>)[], components?: JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>[], files?: AttachmentPayload[]) {
+    let pages: EmbedPage[] = [];
+    let currPage = 0;
+    if (embeds) {
+        // Can't paginate if there are multiple embeds or if there are 5 components
+        if (embeds.length > 1 || (components && components.length === 5))
+            embeds = embeds.map(e => enforceEmbedLimits(e));
+        else {
+            pages = paginateEmbed(enforceEmbedLimits(embeds[0]));
+            if (pages.length > 1)
+                embeds[0] = {...embeds[0], description: pages[0].description, fields: pages[0].fields};
+        }
+    }
+
+    let message: Message;
     if (m instanceof Message)
-        return await m.reply({ content, embeds, components, files });
+        message = await m.reply({ content, embeds, components, files });
     else if (m.replied || m.deferred)
-        return await m.editReply({ content, embeds, components, files });
+        message = await m.editReply({ content, embeds, components, files });
     else {
         await m.reply({ content, embeds, components, files });
-        return await m.fetchReply();
+        message = await m.fetchReply();
     }
+
+    if (pages.length > 1) { // Paginate the embed description/fields
+        const paginationButtons = () => {
+            return new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder()
+                    .setCustomId("pagination:previous")
+                    .setLabel("Previous")
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(currPage === 0),
+                new ButtonBuilder()
+                    .setCustomId("pagination:next")
+                    .setLabel("Next")
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(currPage === pages.length - 1)
+            );
+        };
+
+        if (components)
+            components.push(paginationButtons());
+        else
+            components = [paginationButtons()];
+
+        await message.edit({ content, embeds, components, files });
+
+        const collector = message.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            filter: i => i.user.id === commandUser(m).id && (i.customId === "pagination:previous" || i.customId === "pagination:next"),
+            time: 600000,
+        });
+        collector.on("collect", async i => {
+            if (i.customId === "pagination:previous")
+                currPage--;
+            else if (i.customId === "pagination:next")
+                currPage++;
+
+            components![components!.length - 1] = paginationButtons();
+
+            await message.edit({ content, embeds: [{ ...embeds![0], description: pages[currPage].description, fields: pages[currPage].fields }], components, files });
+        });
+
+        collector.on("end", async () => {
+            // Delete the pagination buttons
+            components!.pop();
+            await message.edit({ content, embeds: [{ ...embeds![0], description: pages[currPage].description, fields: pages[currPage].fields }], components, files });
+        });
+    }
+
+    return message;
 }

--- a/DiscordBot/functions/respond.ts
+++ b/DiscordBot/functions/respond.ts
@@ -1,76 +1,12 @@
-import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, ActionRowBuilder, AttachmentPayload, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, ComponentType, JSONEncodable, Message } from "discord.js";
-import { EmbedPage, enforceEmbedLimits, paginateEmbed } from "./embedHandlers";
-import commandUser from "./commandUser";
+import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, AttachmentPayload, ChatInputCommandInteraction, JSONEncodable, Message } from "discord.js";
 
 export default async function respond (m: Message | ChatInputCommandInteraction, content?: string, embeds?: (APIEmbed | JSONEncodable<APIEmbed>)[], components?: JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>[], files?: AttachmentPayload[]) {
-    let pages: EmbedPage[] = [];
-    let currPage = 0;
-    if (embeds) {
-        // Can't paginate if there are multiple embeds or if there are 5 components
-        if (embeds.length > 1 || (components && components.length === 5))
-            embeds = embeds.map(e => enforceEmbedLimits(e));
-        else {
-            pages = paginateEmbed(enforceEmbedLimits(embeds[0]));
-            if (pages.length > 1)
-                embeds[0] = {...embeds[0], description: pages[0].description, fields: pages[0].fields};
-        }
-    }
-
-    let message: Message;
     if (m instanceof Message)
-        message = await m.reply({ content, embeds, components, files });
+        return await m.reply({ content, embeds, components, files });
     else if (m.replied || m.deferred)
-        message = await m.editReply({ content, embeds, components, files });
+        return await m.editReply({ content, embeds, components, files });
     else {
         await m.reply({ content, embeds, components, files });
-        message = await m.fetchReply();
+        return await m.fetchReply();
     }
-
-    if (pages.length > 1) { // Paginate the embed description/fields
-        const paginationButtons = () => {
-            return new ActionRowBuilder<ButtonBuilder>().addComponents(
-                new ButtonBuilder()
-                    .setCustomId("pagination:previous")
-                    .setLabel("Previous")
-                    .setStyle(ButtonStyle.Secondary)
-                    .setDisabled(currPage === 0),
-                new ButtonBuilder()
-                    .setCustomId("pagination:next")
-                    .setLabel("Next")
-                    .setStyle(ButtonStyle.Secondary)
-                    .setDisabled(currPage === pages.length - 1)
-            );
-        };
-
-        if (components)
-            components.push(paginationButtons());
-        else
-            components = [paginationButtons()];
-
-        await message.edit({ content, embeds, components, files });
-
-        const collector = message.createMessageComponentCollector({
-            componentType: ComponentType.Button,
-            filter: i => i.user.id === commandUser(m).id && (i.customId === "pagination:previous" || i.customId === "pagination:next"),
-            time: 600000,
-        });
-        collector.on("collect", async i => {
-            if (i.customId === "pagination:previous")
-                currPage--;
-            else if (i.customId === "pagination:next")
-                currPage++;
-
-            components![components!.length - 1] = paginationButtons();
-
-            await message.edit({ content, embeds: [{ ...embeds![0], description: pages[currPage].description, fields: pages[currPage].fields }], components, files });
-        });
-
-        collector.on("end", async () => {
-            // Delete the pagination buttons
-            components!.pop();
-            await message.edit({ content, embeds: [{ ...embeds![0], description: pages[currPage].description, fields: pages[currPage].fields }], components, files });
-        });
-    }
-
-    return message;
 }

--- a/DiscordBot/functions/respond.ts
+++ b/DiscordBot/functions/respond.ts
@@ -1,5 +1,5 @@
 import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, ActionRowBuilder, AttachmentPayload, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, ComponentType, JSONEncodable, Message } from "discord.js";
-import { EmbedBuilder } from "./embedHandlers";
+import { EmbedBuilder } from "./embedBuilder";
 import commandUser from "./commandUser";
 
 export default async function respond (m: Message | ChatInputCommandInteraction, content?: string, embeds?: EmbedBuilder | (APIEmbed | JSONEncodable<APIEmbed>)[], components?: JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>[], files?: AttachmentPayload[]) {

--- a/DiscordBot/functions/respond.ts
+++ b/DiscordBot/functions/respond.ts
@@ -1,12 +1,70 @@
-import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, AttachmentPayload, ChatInputCommandInteraction, JSONEncodable, Message } from "discord.js";
+import { APIActionRowComponent, APIEmbed, APIMessageActionRowComponent, ActionRowBuilder, AttachmentPayload, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, ComponentType, JSONEncodable, Message } from "discord.js";
+import { EmbedBuilder } from "./embedHandlers";
+import commandUser from "./commandUser";
 
-export default async function respond (m: Message | ChatInputCommandInteraction, content?: string, embeds?: (APIEmbed | JSONEncodable<APIEmbed>)[], components?: JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>[], files?: AttachmentPayload[]) {
+export default async function respond (m: Message | ChatInputCommandInteraction, content?: string, embeds?: EmbedBuilder | (APIEmbed | JSONEncodable<APIEmbed>)[], components?: JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>[], files?: AttachmentPayload[]) {
+    let pages: APIEmbed[] = [];
+    let currPage = 0;
+    if (embeds instanceof EmbedBuilder) {
+        pages = embeds.build();
+        embeds = [pages[currPage]];
+    }
+
+    let message: Message;
     if (m instanceof Message)
-        return await m.reply({ content, embeds, components, files });
+        message = await m.reply({ content, embeds, components, files });
     else if (m.replied || m.deferred)
-        return await m.editReply({ content, embeds, components, files });
+        message = await m.editReply({ content, embeds, components, files });
     else {
         await m.reply({ content, embeds, components, files });
-        return await m.fetchReply();
+        message = await m.fetchReply();
     }
+
+    if (pages.length > 1) {
+        const paginationButtons = () => {
+            return new ActionRowBuilder<ButtonBuilder>().addComponents(
+                new ButtonBuilder()
+                    .setCustomId("pagination:previous")
+                    .setLabel("Previous")
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(currPage === 0),
+                new ButtonBuilder()
+                    .setCustomId("pagination:next")
+                    .setLabel("Next")
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(currPage === pages.length - 1)
+            );
+        };
+
+        if (!components)
+            components = [paginationButtons()];
+        else
+            components.push(paginationButtons());
+
+        await message.edit({ content, embeds: [pages[currPage]], components, files });
+
+        const collector = message.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            filter: i => i.user.id === commandUser(m).id && (i.customId === "pagination:previous" || i.customId === "pagination:next"),
+            time: 600000,
+        });
+        collector.on("collect", async i => {
+            if (i.customId === "pagination:previous")
+                currPage--;
+            else if (i.customId === "pagination:next")
+                currPage++;
+
+            components![components!.length - 1] = paginationButtons();
+
+            await i.update({ content, embeds: [pages[currPage]], components, files });
+        });
+
+        collector.on("end", async () => {
+            // Delete the pagination buttons
+            components!.pop();
+            await message.edit({ content, embeds: [pages[currPage]], components, files });
+        });
+    }
+
+    return message;
 }

--- a/DiscordBot/functions/tournamentFunctions/mappoolLog.ts
+++ b/DiscordBot/functions/tournamentFunctions/mappoolLog.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, TextChannel } from "discord.js";
+import { TextChannel } from "discord.js";
 import { MappoolMapHistory } from "../../../Models/tournaments/mappools/mappoolMapHistory";
 import { Tournament } from "../../../Models/tournaments/tournament";
 import { TournamentChannel } from "../../../Models/tournaments/tournamentChannel";
@@ -6,6 +6,7 @@ import { User } from "../../../Models/user";
 import modeColour from "../modeColour";
 import { discordClient } from "../../../Server/discord";
 import { TournamentChannelType } from "../../../Interfaces/tournament";
+import { EmbedBuilder } from "../embedHandlers";
 
 export default async function mappoolLog(tournament: Tournament, command: string, user: User, log: MappoolMapHistory, mappoolSlot: string): Promise<void>;
 export default async function mappoolLog(tournament: Tournament, command: string, user: User, event: string): Promise<void>;
@@ -19,15 +20,15 @@ export default async function mappoolLog (tournament: Tournament, command: strin
     if (mappoolLogChannels.length === 0)
         return;
 
-    const embed = new EmbedBuilder();
-    embed.setTitle(`\`${command}\` was run by ${user.osu.username}`);
+    const embed = new EmbedBuilder()
+        .setTitle(`\`${command}\` was run by ${user.osu.username}`);
 
     if (logOrEvent instanceof MappoolMapHistory) {
         const log = logOrEvent;
         embed.setDescription(`${log.link ? "Custom map" : "Beatmap" } was added to slot \`${mappoolSlot!}\``);
         embed.addFields({ name: "Map", value: log.beatmap ? `${log.beatmap.beatmapset.artist} - ${log.beatmap.beatmapset.title} [${log.beatmap.difficulty}]` : `${log.artist} - ${log.title} [${log.difficulty}]`});
         if (log.link) embed.addFields({ name: "Link", value: log.link });
-        embed.setThumbnail(log.beatmap ? `https://b.ppy.sh/thumb/${log.beatmap.beatmapset.ID}l.jpg` : null);
+        embed.setThumbnail(log.beatmap ? `https://b.ppy.sh/thumb/${log.beatmap.beatmapset.ID}l.jpg` : "");
         embed.setColor(modeColour(tournament.mode.ID - 1));
         embed.setTimestamp();
     } else {
@@ -40,6 +41,6 @@ export default async function mappoolLog (tournament: Tournament, command: strin
     await Promise.all(mappoolLogChannels.map(async channel => {
         const c = await discordClient.channels.fetch(channel.channelID) as TextChannel | null;
         if (c)
-            return c.send({ embeds: [embed] });
+            return c.send({ embeds: embed.build() });
     }));
 }

--- a/DiscordBot/functions/tournamentFunctions/mappoolLog.ts
+++ b/DiscordBot/functions/tournamentFunctions/mappoolLog.ts
@@ -6,7 +6,7 @@ import { User } from "../../../Models/user";
 import modeColour from "../modeColour";
 import { discordClient } from "../../../Server/discord";
 import { TournamentChannelType } from "../../../Interfaces/tournament";
-import { EmbedBuilder } from "../embedHandlers";
+import { EmbedBuilder } from "../embedBuilder";
 
 export default async function mappoolLog(tournament: Tournament, command: string, user: User, log: MappoolMapHistory, mappoolSlot: string): Promise<void>;
 export default async function mappoolLog(tournament: Tournament, command: string, user: User, event: string): Promise<void>;

--- a/DiscordBot/handlers/guildMemberAdd.ts
+++ b/DiscordBot/handlers/guildMemberAdd.ts
@@ -1,10 +1,11 @@
-import { EmbedBuilder, EmbedData, GuildMember, TextChannel } from "discord.js";
+import { GuildMember, TextChannel } from "discord.js";
 import { config } from "node-config-ts";
 import { Brackets } from "typeorm";
 import { TournamentRoleType } from "../../Interfaces/tournament";
 import { TournamentRole } from "../../Models/tournaments/tournamentRole";
 import { User } from "../../Models/user";
 import { discordClient } from "../../Server/discord";
+import { EmbedBuilder } from "../functions/embedHandlers";
 
 export default async function guildMemberAdd (member: GuildMember) {
     const tournamentRolesToAdd = await TournamentRole
@@ -64,29 +65,24 @@ export default async function guildMemberAdd (member: GuildMember) {
         }       
 
         const memberUser = member.user;
-        const embed = new EmbedBuilder({
-            title: `${memberUser.username} joined`,
-            description: `Users currently in server: ${member.guild.memberCount}`,
-            color: 3066993,
-            timestamp: new Date(),
-            footer: {
-                iconURL: member.guild.iconURL() ?? undefined,
+        const embed = new EmbedBuilder()
+            .setTitle(`${memberUser.username} joined`)
+            .setDescription(`Users currently in server: ${member.guild.memberCount}`)
+            .setColor(3066993)
+            .setTimestamp()
+            .setFooter({
                 text: "Corsace Logger",
-            },
-            thumbnail: {
-                url: memberUser.avatarURL() ?? undefined,
-            },
-            fields: [
-                {
-                    name: "Registered?",
-                    value: user ? `${memberUser.username} is registered` : `${memberUser.username} isn't registered`,
-                },
-            ],
-        } as EmbedData);
+                icon_url: member.guild.iconURL() ?? undefined,
+            })
+            .setThumbnail(memberUser.avatarURL() ?? "")
+            .addField({
+                name: "Registered?",
+                value: user ? `${memberUser.username} is registered` : `${memberUser.username} isn't registered`,
+            });
 
         const channel = (await discordClient.channels.fetch(config.discord.logChannel))!;
         await (channel as TextChannel).send({
-            embeds: [embed],
+            embeds: embed.build(),
         });
     }
 }

--- a/DiscordBot/handlers/guildMemberAdd.ts
+++ b/DiscordBot/handlers/guildMemberAdd.ts
@@ -5,7 +5,7 @@ import { TournamentRoleType } from "../../Interfaces/tournament";
 import { TournamentRole } from "../../Models/tournaments/tournamentRole";
 import { User } from "../../Models/user";
 import { discordClient } from "../../Server/discord";
-import { EmbedBuilder } from "../functions/embedHandlers";
+import { EmbedBuilder } from "../functions/embedBuilder";
 
 export default async function guildMemberAdd (member: GuildMember) {
     const tournamentRolesToAdd = await TournamentRole

--- a/DiscordBot/handlers/guildMemberRemove.ts
+++ b/DiscordBot/handlers/guildMemberRemove.ts
@@ -1,7 +1,7 @@
 import { GuildMember, PartialGuildMember, TextChannel } from "discord.js";
 import { config } from "node-config-ts";
 import { discordClient } from "../../Server/discord";
-import { EmbedBuilder } from "../functions/embedHandlers";
+import { EmbedBuilder } from "../functions/embedBuilder";
 
 export default async function guildMemberRemove (member: GuildMember | PartialGuildMember) {
 

--- a/DiscordBot/handlers/guildMemberRemove.ts
+++ b/DiscordBot/handlers/guildMemberRemove.ts
@@ -1,29 +1,24 @@
-import { GuildMember, EmbedBuilder, EmbedData, PartialGuildMember, TextChannel } from "discord.js";
+import { GuildMember, PartialGuildMember, TextChannel } from "discord.js";
 import { config } from "node-config-ts";
 import { discordClient } from "../../Server/discord";
+import { EmbedBuilder } from "../functions/embedHandlers";
 
 export default async function guildMemberRemove (member: GuildMember | PartialGuildMember) {
 
     // If this is a user joining the corsace server, add the streamannouncements and verified role as applicable
     const user = await discordClient.users.fetch(member.id);
     if (member.guild.id === config.discord.guild) {
-        const embed = new EmbedBuilder({
-            title: `${user ? user.username : "A user"} left`,
-            description: `Users currently in server: ${member.guild.memberCount}`,
-            color: 15277667,
-            timestamp: new Date(),
-            footer: {
-                icon_url: member.guild.iconURL() ?? undefined,
-                text: "Corsace Logger",
-            },
-            thumbnail: {
-                url: user?.avatarURL() ?? undefined,
-            },
-        } as EmbedData);
+        const embed = new EmbedBuilder()
+            .setTitle(`${user ? user.username : "A user"} left`)
+            .setDescription(`Users currently in server: ${member.guild.memberCount}`)
+            .setColor(15277667)
+            .setTimestamp()
+            .setFooter({ text: "Corsace Logger", icon_url: member.guild.iconURL() ?? undefined })
+            .setThumbnail(user?.avatarURL() ?? "");
 
         const channel = await discordClient.channels.fetch(config.discord.logChannel);
         await (channel as TextChannel).send({
-            embeds: [embed],
+            embeds: embed.build(),
         });
     }
 }

--- a/Server/functions/tournaments/mappool/customBeatmapToNodesu.ts
+++ b/Server/functions/tournaments/mappool/customBeatmapToNodesu.ts
@@ -1,0 +1,72 @@
+import { Beatmap } from "nodesu";
+import { MappoolMap } from "../../../../Models/tournaments/mappools/mappoolMap";
+
+interface CustomBeatmapToNodesu {
+    customBeatmap: NonNullable<MappoolMap["customBeatmap"]>;
+    customMappers: NonNullable<MappoolMap["customMappers"]>;
+    createdAt: NonNullable<MappoolMap["createdAt"]>;
+    lastUpdate: NonNullable<MappoolMap["lastUpdate"]>;
+}
+
+export default function customBeatmapToNodesu ({ customBeatmap, customMappers, createdAt, lastUpdate }: CustomBeatmapToNodesu) {
+    return new Beatmap({
+        "beatmapset_id": "-1",
+        "beatmap_id": "-1",
+        "approved": "-3",
+        "total_length": `${customBeatmap.totalLength}`,
+        "hit_length": `${customBeatmap.hitLength}`,
+        "version": customBeatmap.difficulty,
+        "file_md5": "",
+        "diff_size": `${customBeatmap.circleSize}`,
+        "diff_overall": `${customBeatmap.overallDifficulty}`,
+        "diff_approach": `${customBeatmap.approachRate}`,
+        "diff_drain": `${customBeatmap.hpDrain}`,
+        "mode": `${customBeatmap.mode.ID - 1}`,
+        "count_normal": `${customBeatmap.circles}`,
+        "count_slider": `${customBeatmap.sliders}`,
+        "count_spinner": `${customBeatmap.spinners}`,
+        "submit_date": [
+            createdAt.getUTCMonth() + 1,
+            createdAt.getUTCDate(),
+            createdAt.getUTCFullYear(),
+        ].join("/") + " " + [
+            createdAt.getUTCHours(),
+            createdAt.getUTCMinutes(),
+            createdAt.getUTCSeconds(),
+        ].join(":"),
+        "approved_date": null,
+        "last_update": [
+            lastUpdate.getUTCMonth() + 1,
+            lastUpdate.getUTCDate(),
+            lastUpdate.getUTCFullYear(),
+        ].join("/") + " " + [
+            lastUpdate.getUTCHours(),
+            lastUpdate.getUTCMinutes(),
+            lastUpdate.getUTCSeconds(),
+        ].join(":"),
+        "artist": customBeatmap.artist,
+        "artist_unicode": customBeatmap.artist,
+        "title": customBeatmap.title,
+        "title_unicode": customBeatmap.title,
+        "creator": customMappers.map(u => u.osu.username).join(", "),
+        "creator_id": "-1",
+        "bpm": `${customBeatmap.BPM}`,
+        "source": "",
+        "tags": `${customBeatmap.link ?? ""}`,
+        "genre_id": "0",
+        "language_id": "0",
+        "favourite_count": "0",
+        "rating": "0",
+        "storyboard": "0",
+        "video": "0",
+        "download_unavailable": "0",
+        "audio_unavailable": "0",
+        "playcount": "0",
+        "passcount": "0",
+        "packs": null,
+        "max_combo": customBeatmap.maxCombo ? `${customBeatmap.maxCombo}` : null,
+        "diff_aim": customBeatmap.aimSR ? `${customBeatmap.aimSR}` : null,
+        "diff_speed": customBeatmap.speedSR ? `${customBeatmap.speedSR}` : null,
+        "difficultyrating": `${customBeatmap.totalSR}`,
+    });
+}

--- a/Server/utils/truncate.ts
+++ b/Server/utils/truncate.ts
@@ -1,0 +1,3 @@
+export default function truncate (text: string, maxLength: number) {
+    return text.length > maxLength ? text.slice(0, maxLength - 3) + "..." : text;
+}


### PR DESCRIPTION
Created a new `EmbedBuilder` class to replace the discord.js one that automatically truncates text and checks for char limits
Added pagination options for embed commands
Also dealt with DRY for custom beatmap -> nodesu beatmap conversion


uhhh its easier to test if we ship it because creating random data that will override embed limits is kind of annoying but yea