### PR TITLE
♻️ Terminate HTTP server after all matchups are over

### DIFF
--- a/BanchoBot/handlers/messageHandler.ts
+++ b/BanchoBot/handlers/messageHandler.ts
@@ -3,7 +3,7 @@ import { handleCommand } from "../commands";
 import state from "../state";
 
 export default async function messageHandler (message: PrivateMessage | ChannelMessage) {
-    if (state.shuttingDown)
+    if (state.receivedShutdownSignal)
         return;
 
     // ignore messages from our own user

--- a/BanchoBot/state.ts
+++ b/BanchoBot/state.ts
@@ -9,8 +9,8 @@ export interface MatchupList {
 }
 
 const state = {
+    receivedShutdownSignal: false,
     shuttingDown: false,
-    httpServerShutDown: false,
     runningMatchups: 0,
     matchups: {} as MatchupState,
 };


### PR DESCRIPTION
Opening as a draft for now in lack of testing, but I might just deploy it to production after another read. Worst that can happen is the server won't stop (not stopping the new one from starting), which I can fix manually.