### PR TITLE
Freeze match score display during gameplay

### DIFF
--- a/Open/pages/stream/match.vue
+++ b/Open/pages/stream/match.vue
@@ -335,7 +335,7 @@ export default class Match extends Vue {
         this.loading = false;
     }
 
-    handleData = (ctx: ExtendedPublicationContext) => {
+    handleData (ctx: ExtendedPublicationContext) {
         console.log("publication", ctx);
 
         if (!ctx.channel.startsWith("matchup:"))

--- a/Open/pages/stream/match.vue
+++ b/Open/pages/stream/match.vue
@@ -312,7 +312,7 @@ export default class Match extends Vue {
             console.log("subscribed", ctx);
         });
 
-        this.matchupChannel.on("publication", this.handleData);
+        this.matchupChannel.on("publication", (ctx) => this.handleUpdate(ctx));
 
         this.matchupChannel.subscribe();
 
@@ -335,7 +335,7 @@ export default class Match extends Vue {
         this.loading = false;
     }
 
-    handleData (ctx: ExtendedPublicationContext) {
+    handleUpdate (ctx: ExtendedPublicationContext) {
         console.log("publication", ctx);
 
         if (!ctx.channel.startsWith("matchup:"))

--- a/Open/pages/stream/match.vue
+++ b/Open/pages/stream/match.vue
@@ -1,5 +1,5 @@
 <template>
-    <div 
+    <div
         v-if="matchup"
         class="matchup"
     >
@@ -11,13 +11,13 @@
             MATCH
         </div>
         <div
-            v-if="matchup.team1" 
+            v-if="matchup.team1"
             class="matchup__team1"
         >
             <div class="matchup__team1_abbreviation">
                 {{ matchup.team1.abbreviation.toUpperCase() }}
             </div>
-            <div 
+            <div
                 class="matchup__team1_avatar"
                 :style="{
                     'background-image': `url(${matchup.team1.avatarURL || require('../../../Assets/img/site/open/team/default.png')})`,
@@ -28,20 +28,20 @@
             </div>
             <div class="matchup__team1_score">
                 WINS
-                <svg 
+                <svg
                     v-for="n in firstTo"
                     :key="n"
-                    width="48" 
-                    height="22" 
-                    viewBox="0 0 48 22" 
+                    width="48"
+                    height="22"
+                    viewBox="0 0 48 22"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
                     class="matchup__team1_score__star"
                 >
                     <path
                         d="M 31 22 H 0 L 16 0 H 48 L 31 22 Z"
-                        :fill="matchup.team1Score >= n ? '#F24141FF' : '#F2414100'"
-                        :stroke="matchup.team1Score >= n ? '#F2414100' : '#F24141FF'"
+                        :fill="displayedTeam1Score >= n ? '#F24141FF' : '#F2414100'"
+                        :stroke="displayedTeam1Score >= n ? '#F2414100' : '#F24141FF'"
                     />
                 </svg>
             </div>
@@ -50,7 +50,7 @@
             </div>
         </div>
         <div
-            v-if="latestMap" 
+            v-if="latestMap"
             class="matchup__beatmap"
         >
             <div class="matchup__beatmap__header">
@@ -58,7 +58,7 @@
                     class="matchup__beatmap__name"
                     :style="{color: slotMod}"
                 >
-                    <div 
+                    <div
                         class="matchup__diamond matchup__beatmap__name__diamond"
                         :style="{backgroundColor: slotMod}"
                     />
@@ -104,13 +104,13 @@
             </div>
         </div>
         <div
-            v-if="matchup.team2" 
+            v-if="matchup.team2"
             class="matchup__team2"
         >
             <div class="matchup__team2_abbreviation">
                 {{ matchup.team2.abbreviation.toUpperCase() }}
             </div>
-            <div 
+            <div
                 class="matchup__team2_avatar"
                 :style="{
                     'background-image': `url(${matchup.team2.avatarURL || require('../../../Assets/img/site/open/team/default.png')})`,
@@ -120,20 +120,20 @@
                 {{ matchup.team2.name }}
             </div>
             <div class="matchup__team2_score">
-                <svg 
+                <svg
                     v-for="n in firstTo"
                     :key="n"
-                    width="48" 
-                    height="22" 
-                    viewBox="0 0 48 22" 
+                    width="48"
+                    height="22"
+                    viewBox="0 0 48 22"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
                     class="matchup__team2_score__star"
                 >
                     <path
                         d="M 16 22 H 48 L 31 0 H 0.684986 L 16 22 Z"
-                        :fill="matchup.team2Score >= n ? '#5BBCFAFF' : '#5BBCFA00'"
-                        :stroke="matchup.team2Score >= n ? '#5BBCFA00' : '#5BBCFAFF'"
+                        :fill="displayedTeam2Score >= n ? '#5BBCFAFF' : '#5BBCFA00'"
+                        :stroke="displayedTeam2Score >= n ? '#5BBCFA00' : '#5BBCFAFF'"
                     />
                 </svg>
                 WINS
@@ -147,7 +147,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component } from "vue-property-decorator";
+import { Vue, Component, Watch } from "vue-property-decorator";
 import { namespace } from "vuex-class";
 import MappoolMapStats from "../../../Assets/components/open/MappoolMapStats.vue";
 
@@ -179,6 +179,10 @@ export default class Match extends Vue {
     latestMap: MappoolMap | null = null;
     loading = false;
 
+    freezeTeamScores = false;
+    displayedTeam1Score = 0;
+    displayedTeam2Score = 0;
+
     get pickedMaps () {
         if (!this.matchup?.sets?.[this.matchup.sets.length - 1]?.maps)
             return [];
@@ -194,7 +198,7 @@ export default class Match extends Vue {
         const pickOrder = this.mapOrder[(this.matchup?.sets?.[this.matchup.sets.length - 1]?.order ?? 1) - 1]?.order?.filter(p => p.status === MapStatus.Picked);
         if (!pickOrder)
             return null;
-    
+
         const currentOrder = this.pickedMaps.length > pickOrder.length ? null : pickOrder[this.pickedMaps.length];
         const first = this.matchup?.sets?.[this.matchup.sets.length - 1]?.first?.abbreviation.toUpperCase();
         const second = this.matchup?.team1?.ID === this.matchup?.sets?.[this.matchup.sets.length - 1]?.first?.ID ? this.matchup?.team2?.abbreviation.toUpperCase() : this.matchup?.team2?.ID === this.matchup?.sets?.[this.matchup.sets.length - 1]?.first?.ID ? this.matchup?.team1?.abbreviation.toUpperCase() : null;
@@ -225,7 +229,7 @@ export default class Match extends Vue {
         const slot = this.stageOrRound?.mappool
             .flatMap(m => m.slots)
             .find(s => s.maps.some(m => m.ID === this.latestMap?.ID));
-    
+
         if (!slot)
             return this.RGBValuesToRGBCSS(modsToRGB(0));
 
@@ -275,7 +279,7 @@ export default class Match extends Vue {
 
         this.centrifuge = centrifuge;
 
-        const { data } = await this.$axios.get<{ 
+        const { data } = await this.$axios.get<{
             matchup: MatchupInterface;
             stageOrRound: Stage | Round;
         }>(`/api/matchup/${matchupID}`);
@@ -342,7 +346,7 @@ export default class Match extends Vue {
 
         switch (ctx.data.type) {
             case "first":
-                this.$set(this.matchup, "first", ctx.data.first === this.matchup.team1?.ID ? this.matchup.team1 : this.matchup.team2); // In order to make the computed properties watchers work 
+                this.$set(this.matchup, "first", ctx.data.first === this.matchup.team1?.ID ? this.matchup.team1 : this.matchup.team2); // In order to make the computed properties watchers work
                 break;
             case "beatmap": {
                 const ID = ctx.data.beatmapID;
@@ -356,8 +360,21 @@ export default class Match extends Vue {
                 this.matchup.team1Score = ctx.data.team1Score;
                 this.matchup.team2Score = ctx.data.team2Score;
                 break;
+            case "ipcState":
+                this.freezeTeamScores = ctx.data.ipcState === "Playing";
+                break;
         }
-    };
+    }
+
+    @Watch("matchup.team1Score")
+    @Watch("matchup.team2Score")
+    @Watch("freezeTeamScores")
+    refreshTeamScores () {
+        if (!this.freezeTeamScores) {
+            this.displayedTeam1Score = this.matchup?.team1Score ?? 0;
+            this.displayedTeam2Score = this.matchup?.team2Score ?? 0;
+        }
+    }
 }
 </script>
 
@@ -603,7 +620,7 @@ export default class Match extends Vue {
         &_avatar {
             left: 0;
         }
-        
+
         &_name {
             left: 188px;
             color: #F24141;

--- a/Open/store/stream.ts
+++ b/Open/store/stream.ts
@@ -30,7 +30,7 @@ export const getters: GetterTree<StreamState, OpenState> = {
 export const actions: ActionTree<StreamState, OpenState> = {
     async setScores ({ commit }, stageID) {
         const generalState = this.state as any;
-        const { data } = await this.$axios.get<{ scores: MatchupScore[] }>(`/api/${stageID}/scores?key=${generalState.stream.key}`);
+        const { data } = await this.$axios.get<{ scores: MatchupScore[] }>(`/api/stage/${stageID}/scores?key=${generalState.stream.key}`);
 
         if (data.success)
             commit("setScores", data.scores);

--- a/Typing/centrifuge-shim.d.ts
+++ b/Typing/centrifuge-shim.d.ts
@@ -90,6 +90,11 @@ declare module "centrifuge" {
         team: TeamList;
     }
 
+    interface IpcStateData {
+        type: "ipcState";
+        ipcState: string;
+    }
+
     type PublicationData =
         CreatedData |
         MessageData |
@@ -102,7 +107,8 @@ declare module "centrifuge" {
         MatchFinishedData |
         ClosedData |
         InviteData |
-        TeamRegisteredData;
+        TeamRegisteredData |
+        IpcStateData;
 
     interface ExtendedPublicationContext extends PublicationContext {
         data: PublicationData;


### PR DESCRIPTION
Per discussion with @cavoeboy, made it compatible with Advanced Scene Switcher, so this doesn't require any new component on the streaming side, though I'm not sure if that's the best way to do it:  
![image](https://github.com/user-attachments/assets/c9a873bb-b0ca-479f-b445-05b9685b3fcd)

Also, we should really refactor the tournament key check, so this code isn't duplicated all over the place.