### PR TITLE
⚡️ Optimize tournament staffInfo and staff response time

### DIFF
--- a/Server/api/routes/tournament/index.ts
+++ b/Server/api/routes/tournament/index.ts
@@ -7,7 +7,7 @@ import { TeamList, TeamMember } from "../../../../Interfaces/team";
 import { StaffList, StaffMember, OpenStaffInfo, BaseStaffMember, OpenStaffInfoList } from "../../../../Interfaces/staff";
 import { Team } from "../../../../Models/tournaments/team";
 import { playingRoles, TournamentRoleType, tournamentStaffRoleOrder } from "../../../../Interfaces/tournament";
-import { discordClient } from "../../../discord";
+import { discordClient, fetchAllMembers } from "../../../discord";
 import { Mappool } from "../../../../Models/tournaments/mappools/mappool";
 import { User } from "../../../../Models/user";
 import { createHash } from "crypto";
@@ -436,7 +436,7 @@ tournamentRouter.$get<{ info: OpenStaffInfo }>("/:tournamentID/staffInfo", isLog
 
     try {
         const server = await discordClient.guilds.fetch(tournament.server);
-        await server.members.fetch();
+        await fetchAllMembers(server.id);
         const staff: OpenStaffInfoList[] = [];
 
         const organizer = await User

--- a/Server/api/routes/tournament/index.ts
+++ b/Server/api/routes/tournament/index.ts
@@ -455,12 +455,11 @@ tournamentRouter.$get<{ info: OpenStaffInfo }>("/:tournamentID/staffInfo", isLog
             });
 
         const userDiscordIds = new Set<string>();
-        for (const role of roles) {
-            const discordRole = await server.roles.fetch(role.roleID);
-            if (!discordRole)
+        for (const member of server.members.cache.values()) {
+            if (member.user.bot)
                 continue;
-
-            discordRole.members.filter(m => !m.user.bot).forEach(m => userDiscordIds.add(m.id));
+            if (member.roles.cache.some(r => roles.some(role => role.roleID === r.id)))
+                userDiscordIds.add(member.id);
         }
 
         const dbUsers = await User

--- a/Server/api/routes/tournament/index.ts
+++ b/Server/api/routes/tournament/index.ts
@@ -4,7 +4,7 @@ import { Tournament } from "../../../../Models/tournaments/tournament";
 import { BaseQualifier } from "../../../../Interfaces/qualifier";
 import { Next } from "koa";
 import { TeamList, TeamMember } from "../../../../Interfaces/team";
-import { StaffList, StaffMember, OpenStaffInfo, BaseStaffMember, OpenStaffInfoList } from "../../../../Interfaces/staff";
+import { StaffList, StaffMember, OpenStaffInfo, OpenStaffInfoList } from "../../../../Interfaces/staff";
 import { Team } from "../../../../Models/tournaments/team";
 import { playingRoles, TournamentRoleType, tournamentStaffRoleOrder } from "../../../../Interfaces/tournament";
 import { discordClient, fetchAllMembers } from "../../../discord";

--- a/Server/api/routes/tournament/index.ts
+++ b/Server/api/routes/tournament/index.ts
@@ -435,8 +435,8 @@ tournamentRouter.$get<{ info: OpenStaffInfo }>("/:tournamentID/staffInfo", isLog
     roles.sort((a, b) => tournamentStaffRoleOrder.indexOf(a.roleType) - tournamentStaffRoleOrder.indexOf(b.roleType));
 
     try {
-        const server = await discordClient.guilds.fetch(tournament.server);
-        await fetchAllMembers(server.id);
+        await fetchAllMembers(tournament.server);
+        const server = discordClient.guilds.cache.get(tournament.server)!;
         const staff: OpenStaffInfoList[] = [];
 
         const organizer = await User

--- a/Server/discord.ts
+++ b/Server/discord.ts
@@ -3,7 +3,7 @@ import { config } from "node-config-ts";
 
 // Add more later as needed
 // TODO: See which intents are required after (most) commands are imported from Maquia
-const discordClient = new Client({ 
+const discordClient = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMembers,
@@ -44,4 +44,13 @@ async function getMember (ID: string): Promise<GuildMember | undefined> {
     return member;
 }
 
-export { discordClient, discordGuild, getMember };
+// All members only need to be fetched once per guild, they are then cached indefinitely
+const cachedAllMembersGuilds = new Set<string>();
+async function fetchAllMembers (guildID: string): Promise<void> {
+    if (cachedAllMembersGuilds.has(guildID))
+        return;
+    await (await discordClient.guilds.fetch(guildID))?.members.fetch();
+    cachedAllMembersGuilds.add(guildID);
+}
+
+export { discordClient, discordGuild, getMember, fetchAllMembers };


### PR DESCRIPTION
That one took quite a few rounds. In the end, this netted many gains:
- Aggregated looped SQL queries into one (impact hard to gauge on remote DB)
- Replace `validateTournament` middleware by `validateID` to combine 3 SQL queries into one (impact hard to gauge on remote DB)
- Only call and fetch every members from Discord API on first usage (they are then cached and updated in real-time through Discord's gateway, saves ~250ms on subsequent calls)
- Iterate over every member in the guild only once instead of twice for every role (saves 100ms even on a recent CPU!)

In total: ~1.1s -> ~150ms

---

Applied same techniques to /staff. Response time improved from ~1.1s to ~150ms, removed caching.

And after applying these optimizations, the code for both endpoints is near identical now. I don't think we need two separate endpoints, we could just add `userRoles` to `/staff` and it'd be identical functionality-wise. Would just need to filter out users who never logged in where necessary in the front-end.