### PR TITLE
Add past messages to ref page

### DIFF
--- a/Interfaces/matchup.ts
+++ b/Interfaces/matchup.ts
@@ -1,7 +1,7 @@
 import { Stage } from "./stage";
 import { Round } from "./round";
 import { Team, TeamList } from "./team";
-import { User } from "./user";
+import { User, UserSummary } from "./user";
 import { Mappool, MappoolMap } from "./mappool";
 import { BaseStaffMember } from "./staff";
 
@@ -42,7 +42,7 @@ export interface Matchup extends BaseMatchup {
     referee?:           User | null;
     streamer?:          User | null;
     commentators?:      User[] | null;
-    messages?:          MatchupMessage[] | null;
+    messages?:          MatchupMessageDetailed[] | null;
 }
 
 export enum MapStatus {
@@ -71,8 +71,15 @@ export interface MatchupMap {
 export interface MatchupMessage {
     ID: number;
     timestamp: Date;
-    user: User;
     content: string;
+}
+
+export interface MatchupMessageBasic extends MatchupMessage {
+    user: UserSummary;
+}
+
+export interface MatchupMessageDetailed extends MatchupMessage {
+    user: User;
 }
 
 export interface MatchupScore {

--- a/Interfaces/matchup.ts
+++ b/Interfaces/matchup.ts
@@ -1,7 +1,7 @@
 import { Stage } from "./stage";
 import { Round } from "./round";
 import { Team, TeamList } from "./team";
-import { User, UserSummary } from "./user";
+import { User, UserMessage } from "./user";
 import { Mappool, MappoolMap } from "./mappool";
 import { BaseStaffMember } from "./staff";
 
@@ -75,7 +75,7 @@ export interface MatchupMessage {
 }
 
 export interface MatchupMessageBasic extends MatchupMessage {
-    user: UserSummary;
+    user: UserMessage;
 }
 
 export interface MatchupMessageDetailed extends MatchupMessage {

--- a/Interfaces/user.ts
+++ b/Interfaces/user.ts
@@ -61,6 +61,14 @@ export interface User {
     influences: Influence[];
 }
 
+export interface UserSummary {
+    ID: number;
+    osu: {
+        userID: string;
+        username: string;
+    }
+}
+
 export interface OAuth {
     userID: string;
     username: string;

--- a/Interfaces/user.ts
+++ b/Interfaces/user.ts
@@ -61,7 +61,7 @@ export interface User {
     influences: Influence[];
 }
 
-export interface UserSummary {
+export interface UserMessage {
     ID: number;
     osu: {
         userID: string;

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -677,7 +677,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
     inputMessage = "";
     keywords = "";
     showScrollBottom = false;
-    fetchedAllMessages = false;
+    fetchedAllMessages = true;
     loadingMessages = false;
     messages: MatchupMessageBasic[] = [];
     showBanchoMessages = true;

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -565,7 +565,7 @@ import ContentButton from "../../../Assets/components/open/ContentButton.vue";
 import OpenSelect from "../../../Assets/components/open/OpenSelect.vue";
 import OpenTitle from "../../../Assets/components/open/OpenTitle.vue";
 import { Tournament } from "../../../Interfaces/tournament";
-import { MapStatus, Matchup, MatchupSet } from "../../../Interfaces/matchup";
+import { MapStatus, Matchup, MatchupSet, MatchupMessageBasic } from "../../../Interfaces/matchup";
 import { MapOrder, MapOrderTeam } from "../../../Interfaces/stage";
 import { UserInfo } from "../../../Interfaces/user";
 import { Mappool, MappoolMap, MappoolSlot } from "../../../Interfaces/mappool";
@@ -585,19 +585,6 @@ interface playerState {
     mods: string;
     slot: number;
     team?: "Blue" | "Red";
-}
-
-interface message {
-    ID: number;
-    timestamp: Date;
-    content: string;
-    user: {
-        ID: number;
-        osu: {
-            userID: string;
-            username: string;
-        }
-    }
 }
 
 @Component({
@@ -668,13 +655,13 @@ export default class Referee extends Mixins(CentrifugeMixin) {
 
     inputMessage = "";
     showScrollBottom = false;
-    messages: message[] = [];
+    messages: MatchupMessageBasic[] = [];
     showBanchoMessages = true;
     showBanchoSettings = false;
     showCorsaceMessages = true;
     autoSendNextMapMessage = false;
 
-    get filteredMessages (): message[] {
+    get filteredMessages (): MatchupMessageBasic[] {
         return this.messages.filter(message => {
             if (!message.user?.osu || message.user.osu.userID === "3")
                 message.user = {

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -677,7 +677,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
     inputMessage = "";
     keywords = "";
     showScrollBottom = false;
-    loadMoreMessages = false;
+    fetchedAllMessages = false;
     loadingMessages = false;
     messages: MatchupMessageBasic[] = [];
     showBanchoMessages = true;
@@ -1082,7 +1082,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
             if (!messagesData.success) {
                 alert("Failed to fetch messages. Check console for more information.");
                 console.error(messagesData.error);
-                this.loadMoreMessages = false;
+                this.fetchedAllMessages = false;
             } else {
                 const newMessages = messagesData.messages.map(message => ({
                     ...message,
@@ -1106,11 +1106,11 @@ export default class Referee extends Mixins(CentrifugeMixin) {
                     ...this.messages,
                 ];
 
-                this.loadMoreMessages = messagesData.messages.length === 50;
+                this.fetchedAllMessages = messagesData.messages.length === 50;
                 
                 await this.$nextTick();
                 messageContainer = document.getElementById("messageContainer"); // In case it was null before and now it's not
-                if (messageContainer && messageContainer.scrollHeight === messageContainer.clientHeight && this.loadMoreMessages) {
+                if (messageContainer && messageContainer.scrollHeight === messageContainer.clientHeight && this.fetchedAllMessages) {
                     await this.loadMessages(toBottom);
                     return;
                 }
@@ -1128,7 +1128,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
         } catch (error) {
             alert("Failed to fetch messages. Check console for more information.");
             console.error(error);
-            this.loadMoreMessages = false;
+            this.fetchedAllMessages = false;
         } finally {
             this.loadingMessages = false;
         }
@@ -1152,7 +1152,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
             return;
 
         this.showScrollBottom = messageContainer.scrollTop + messageContainer.clientHeight !== messageContainer.scrollHeight;
-        if (messageContainer.scrollTop < 100 && this.loadMoreMessages && !this.loadingMessages)
+        if (messageContainer.scrollTop < 100 && this.fetchedAllMessages && !this.loadingMessages)
             await this.loadMessages(false);
     }
 

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -239,6 +239,7 @@
                                     v-for="message in filteredMessages"
                                     :key="message.ID"
                                     class="referee__matchup__messages__message"
+                                    :style="{ color: keywordsArray.some(keyword => message.content.toLowerCase().includes(keyword.toLowerCase())) ? '#EF3255' : 'white' }"
                                 >
                                     <div class="referee__matchup__messages__message__timestamp">
                                         {{ formatTime(message.timestamp) }}
@@ -246,18 +247,26 @@
                                     <div class="referee__matchup__messages__message__user">
                                         {{ message.user.osu.username }}:
                                     </div>
-                                    <div class="referee__matchup__messages__message__content">
+                                    <div
+                                        class="referee__matchup__messages__message__content"
+                                    >
                                         {{ message.content }}
                                     </div>
                                 </div>
                             </div>
-                            <div
-                                v-if="showScrollBottom"
-                                class="referee__matchup__messages__container__scrollBottom"
-                                @click="scrollToBottom()"
+                            <transition
+                                @before-enter="scrollButtonTransition"
+                                @enter="scrollButtonTransition"
+                                @leave="scrollButtonTransition"
                             >
-                                Scroll to bottom
-                            </div>
+                                <div
+                                    v-if="showScrollBottom"
+                                    class="referee__matchup__messages__container__scrollBottom"
+                                    @click="scrollToBottom()"
+                                >
+                                    Scroll to bottom
+                                </div>
+                            </transition>
                         </div>
                         <div
                             v-if="loggedInUser && runningLobby"
@@ -709,6 +718,12 @@ export default class Referee extends Mixins(CentrifugeMixin) {
         return this.matchup?.sets?.[this.matchup.sets.length - 1];
     }
 
+    get keywordsArray () {
+        if (!this.keywords)
+            return [];
+        return this.keywords.split(",").map(keyword => keyword.trim());
+    }
+
     get nextMapMessage () {
         // TODO: Support sets
         const score = `${this.matchup?.team1?.name ?? "TBD"} | ${Number.isInteger(this.matchupSet?.team1Score) ? this.matchupSet?.team1Score : this.matchup?.team1Score} - ${Number.isInteger(this.matchupSet?.team2Score) ? this.matchupSet?.team2Score : this.matchup?.team2Score} | ${this.matchup?.team2?.name ?? "TBD"}`;
@@ -939,6 +954,11 @@ export default class Referee extends Mixins(CentrifugeMixin) {
 
     updated () {
         this.checkScrollPosition().catch(console.error);
+    }
+
+    scrollButtonTransition (e: HTMLElement) {
+        e.style.opacity = this.showScrollBottom ? "1" : "0";
+        e.style.height = this.showScrollBottom ? "50px" : "0";
     }
 
     saveToLocalStorage (type: string, e: InputEvent) {
@@ -1514,7 +1534,6 @@ export default class Referee extends Mixins(CentrifugeMixin) {
                     position: sticky;
                     background-color: rgba(0, 0, 0, 0.5);
                     width: 100%;
-                    height: 50px;
                     bottom: 0;
                     display: flex;
                     align-items: center;

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -239,7 +239,10 @@
                                     v-for="message in filteredMessages"
                                     :key="message.ID"
                                     class="referee__matchup__messages__message"
-                                    :style="{ color: keywordsArray.some(keyword => message.content.toLowerCase().includes(keyword.toLowerCase())) ? '#EF3255' : 'white' }"
+                                    :style="{
+                                        color: message.user.osu.userID === '3' ? '#e98792' : message.user.osu.userID === '29191632' ? '#ef3255' : 'white',
+                                        backgroundColor: keywordsArray.some(keyword => message.content.toLowerCase().includes(keyword.toLowerCase())) ? '#29a8f955' : 'transparent',
+                                    }"
                                 >
                                     <div class="referee__matchup__messages__message__timestamp">
                                         {{ formatTime(message.timestamp) }}
@@ -1563,6 +1566,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
                 display: flex;
                 align-items: baseline;
                 gap: 5px;
+                padding-left: 2px;
 
                 &__timestamp {
                     font-size: $font-sm;

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -297,6 +297,14 @@
                                 >
                             </div>
                         </div>
+                        <div class="referee__matchup__messages__input_div">
+                            <input
+                                v-model="keywords"
+                                class="referee__matchup__messages__input"
+                                placeholder="Your comma separated keywords to highlight..."
+                                @input="saveToLocalStorage('keywords', $event)"
+                            >
+                        </div>
                     </div>
                 </div>
                 <div class="referee__matchup__content">
@@ -308,6 +316,7 @@
                                     v-model="settingsBuffer"
                                     class="referee__matchup__messages__input"
                                     style="width: 40px; flex: 0;"
+                                    @input="saveToLocalStorage('settingsBuffer', $event)"
                                 >
                             </div>
                             <ContentButton
@@ -654,6 +663,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
     readyTimer = "90";
 
     inputMessage = "";
+    keywords = "";
     showScrollBottom = false;
     loadMoreMessages = false;
     loadingMessages = false;
@@ -916,6 +926,9 @@ export default class Referee extends Mixins(CentrifugeMixin) {
         this.mapTimer = `${this.tournament?.mapTimer ?? 90}`;
         this.readyTimer = `${this.tournament?.readyTimer ?? 90}`;
 
+        this.keywords = localStorage.getItem("keywords") ?? "";
+        this.settingsBuffer = parseInt(localStorage.getItem("settingsBuffer") ?? "5");
+
         await this.loadMessages(true);
 
         await this.initCentrifuge(`matchup:${this.$route.params.id}`);
@@ -926,6 +939,11 @@ export default class Referee extends Mixins(CentrifugeMixin) {
 
     updated () {
         this.checkScrollPosition().catch(console.error);
+    }
+
+    saveToLocalStorage (type: string, e: InputEvent) {
+        const target = e.target as HTMLInputElement;
+        localStorage.setItem(type, target.value);
     }
 
     formatDate (date: Date): string {

--- a/Open/pages/referee/_id.vue
+++ b/Open/pages/referee/_id.vue
@@ -1082,7 +1082,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
             if (!messagesData.success) {
                 alert("Failed to fetch messages. Check console for more information.");
                 console.error(messagesData.error);
-                this.fetchedAllMessages = false;
+                this.fetchedAllMessages = true;
             } else {
                 const newMessages = messagesData.messages.map(message => ({
                     ...message,
@@ -1106,11 +1106,11 @@ export default class Referee extends Mixins(CentrifugeMixin) {
                     ...this.messages,
                 ];
 
-                this.fetchedAllMessages = messagesData.messages.length === 50;
+                this.fetchedAllMessages = messagesData.messages.length !== 50;
                 
                 await this.$nextTick();
                 messageContainer = document.getElementById("messageContainer"); // In case it was null before and now it's not
-                if (messageContainer && messageContainer.scrollHeight === messageContainer.clientHeight && this.fetchedAllMessages) {
+                if (messageContainer && messageContainer.scrollHeight === messageContainer.clientHeight && !this.fetchedAllMessages) {
                     await this.loadMessages(toBottom);
                     return;
                 }
@@ -1128,7 +1128,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
         } catch (error) {
             alert("Failed to fetch messages. Check console for more information.");
             console.error(error);
-            this.fetchedAllMessages = false;
+            this.fetchedAllMessages = true;
         } finally {
             this.loadingMessages = false;
         }
@@ -1152,7 +1152,7 @@ export default class Referee extends Mixins(CentrifugeMixin) {
             return;
 
         this.showScrollBottom = messageContainer.scrollTop + messageContainer.clientHeight !== messageContainer.scrollHeight;
-        if (messageContainer.scrollTop < 100 && this.fetchedAllMessages && !this.loadingMessages)
+        if (messageContainer.scrollTop < 100 && !this.fetchedAllMessages && !this.loadingMessages)
             await this.loadMessages(false);
     }
 

--- a/Server/api/routes/referee/bancho.ts
+++ b/Server/api/routes/referee/bancho.ts
@@ -53,9 +53,8 @@ refereeBanchoRouter.$post<object, TournamentAuthenticatedState>("/:tournamentID/
         if (axios.isAxiosError(e)) {
             ctx.body = e.response?.data ?? {
                 success: false,
-                error: e.message,
+                error: e.response?.status ? `Status code: ${e.response.status}\n${e.message}` : e.message,
             };
-            ctx.status = e.response?.status ?? 500;
         } else if (e instanceof Error) {
             ctx.body = {
                 success: false,

--- a/Server/api/routes/referee/matchups.ts
+++ b/Server/api/routes/referee/matchups.ts
@@ -103,7 +103,7 @@ refereeMatchupsRouter.$get<{ messages: MatchupMessageInterface[] }>("/:tournamen
         messagesQ.andWhere("message.ID < :beforeID", { beforeID });
 
     const messages = await messagesQ
-        .orderBy("message.timestamp", "DESC")
+        .orderBy("message.ID", "DESC")
         .take(50)
         .getMany();
 

--- a/Typing/centrifuge-shim.d.ts
+++ b/Typing/centrifuge-shim.d.ts
@@ -2,6 +2,7 @@ import "centrifuge";
 import { PublicationContext } from "centrifuge";
 import { MatchupMap } from "../Interfaces/matchup";
 import { BaseTeam, TeamList } from "../Interfaces/team";
+import { UserMessage } from "../Interfaces/user";
 
 declare module "centrifuge" {
 
@@ -23,13 +24,7 @@ declare module "centrifuge" {
         type: "message";
         timestamp: Date;
         content: string;
-        user: {
-            ID: number;
-            osu: {
-                userID: string;
-                username: string;
-            };
-        }
+        user: UserMessage;
     }
 
     interface FirstData {

--- a/centrifugo-config.json
+++ b/centrifugo-config.json
@@ -15,7 +15,10 @@
     "namespaces": [
         {
             "name": "matchup",
-            "proxy_subscribe": true
+            "proxy_subscribe": true,
+            "history_size": 300,
+            "history_ttl": "20s",
+            "allow_history_for_subscriber": true
         },
         {
             "name": "invitations",


### PR DESCRIPTION
Harder than it sounds

Also added localstorage saving for `settingsbuffer` and chat keywords for highlighting
Also some other fixes see commits below if interested

Tested with:
loading some old corsace open 2023 lobby
running a new lobby
loading a lobby with very few messages