### PR TITLE
Better Bancho hiccups handling

### DIFF
--- a/BanchoBot/functions/tournaments/matchup/runMatchup.ts
+++ b/BanchoBot/functions/tournaments/matchup/runMatchup.ts
@@ -234,6 +234,8 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
         if (!state.matchups[matchup.ID])
             return;
 
+        log(matchup, `${message.user.ircUsername} says: ${message.content}`);
+
         const user = await getUserInMatchup(users, message);
         const matchupMessage = new MatchupMessage();
         matchupMessage.timestamp = new Date();

--- a/BanchoBot/functions/tournaments/matchup/runMatchup.ts
+++ b/BanchoBot/functions/tournaments/matchup/runMatchup.ts
@@ -145,18 +145,23 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
     const pause = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
     // Periodically save messages every 15 seconds
-    const messageSaver = setInterval(async () => {
-        const messagesToSave = matchup.messages!.filter((message) => message.timestamp.getTime() > lastMessageSaved);
-        if (messagesToSave.length > 0) {
-            await MatchupMessage
-                .createQueryBuilder()
-                .insert()
-                .values(messagesToSave)
-                .execute();
+    const saveMessages = async () => {
+        try {
+            const messagesToSave = matchup.messages!.filter((message) => message.timestamp.getTime() > lastMessageSaved);
+            if (messagesToSave.length > 0) {
+                await MatchupMessage
+                    .createQueryBuilder()
+                    .insert()
+                    .values(messagesToSave)
+                    .execute();
 
-            lastMessageSaved = messagesToSave[messagesToSave.length - 1].timestamp.getTime();
+                lastMessageSaved = messagesToSave[messagesToSave.length - 1].timestamp.getTime();
+            }
+        } catch(err) {
+            log(matchup, `Error saving messages: ${err}`);
         }
-    }, 15 * 1000);
+    };
+    const saveMessagesInterval = setInterval(saveMessages, 15 * 1000);
 
     // Close lobby 15 minutes after matchup time if not all captains had joined
     setTimeout(async () => {
@@ -786,12 +791,44 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
         }, matchup.streamer ? 30 * 1000 : leniencyTime);
     });
 
-    mpLobby.channel.on("PART", async (member) => {
-        if (member.user.isClient()) {
-            // Lobby is closed
-            invCollector?.stop();
-            refCollector?.stop();
+    const connectionListener = async () => {
+        log(matchup, `Trying to re-join channel ${mpLobby.id}`);
+        try {
+            await mpChannel.join();
+            log(matchup, `Re-joined channel, informing users and triggering panic`);
+            mpChannel.sendMessage("Encountered an IRC connection issue, match will resume upon human review.")
+                .catch((err) => log(matchup, `Error while notifying users of connection issue: ${err}`));
+            panic("Bancho client disconnected")
+                .catch((err) => log(matchup, `Error while panicking: ${err}`));
+        } catch(err) {
+            // Most likely Bancho actually rebooted, so we should terminate the lobby
+            log(matchup, `Failed to re-join lobby ${mpLobby.id}, terminating: ${err}`);
+            await terminateLobby();
+        }
+    };
+    banchoClient.on("connected", connectionListener);
 
+    mpChannel.on("PART", (member) => {
+        if (!member.user.isClient())
+            return;
+
+        // In case of a disconnection, bancho.js is firing PART events before updating `connectState`, so we must wait a tick before checking.
+        // If we're disconncted, trying to rejoin the channel before terminating.
+        process.nextTick(() => {
+            if (!banchoClient.isConnected())
+                return;
+            void terminateLobby();
+        });
+    });
+
+    async function terminateLobby () {
+        // Lobby is closed
+        invCollector?.stop();
+        refCollector?.stop();
+        banchoClient.removeListener("connected", connectionListener);
+        clearInterval(saveMessagesInterval);
+
+        try {
             // If forfeit, save from the state because forfeit is assigned from the ref endpoint, not the bot (and the below functionality would remove it otherwise)
             if (state.matchups[matchup.ID] && state.matchups[matchup.ID].matchup.forfeit)
                 matchup = state.matchups[matchup.ID].matchup;
@@ -805,20 +842,19 @@ async function runMatchupListeners (matchup: Matchup, mpLobby: BanchoLobby, mpCh
                 await matchup.save();
 
                 await assignTeamsToNextMatchup(matchup.ID);
-            } else 
+            } else
                 await matchup.save();
-
-            await publish(centrifugoChannel, { type: "closed" });
-
-            // Let messageSaver run one more time before clearing
-            await pause(15 * 1000);
-            clearInterval(messageSaver);
+        } catch(err) {
+            log(matchup, `Error while terminating lobby: ${err}`);
+        } finally {
+            await saveMessages();
+            await publish(centrifugoChannel, { type: "closed" }).catch((err) => log(matchup, `Error while publishing closed event: ${err}`));
 
             state.runningMatchups--;
             delete state.matchups[matchup.ID];
             await maybeShutdown();
         }
-    });
+    }
 }
 
 export default async function runMatchup (matchup: Matchup, replace = false, auto = false, runBy?: string) {

--- a/BanchoBot/index.ts
+++ b/BanchoBot/index.ts
@@ -24,14 +24,20 @@ const banchoClient = new BanchoClient({
     botAccount: config.osu.bancho.botAccount,
     apiKey: config.osu.v1.apiKey,
 });
-banchoClient.connect().catch(err => {
-    if (err) throw err;
+banchoClient.connect()
+    .then(() => {
+        console.log(`Logged into Bancho as ${banchoClient.getSelf().ircUsername}`);
+        banchoClient.on("state", (connectState) => {
+            console.log(`Bancho state: ${connectState}`);
+        });
+    })
+    .catch(err => {
+        console.error("Failed to connect to Bancho.", err);
+        process.exit(1);
+    });
+banchoClient.on("PM", (msg) => {
+    console.log(`[PM] ${msg.user.ircUsername} says to ${msg.recipient.ircUsername}: ${msg.content}`);
 });
-
-banchoClient.on("connected", () => {
-    console.log(`Logged into Bancho as ${banchoClient.getSelf().ircUsername}`);
-});
-
 banchoClient.on("PM", messageHandler);
 
 banchoClient.on("CM", messageHandler);


### PR DESCRIPTION
- Ignore channel left event in case we're disconnected from Bancho
- On next reconnection, try rejoining the lobby.
  - If success: trigger panic
  - If failed: assume Bancho restarted, terminate the lobby

Also assume this could be a network issue on our end, so made sure the lobby can be safely terminated even if connection to database is lost, and log every chat message so no data is lost forever.

Also add better logging of Bancho connection states.