### PR TITLE
🚑️ Do not save matchup messages while saving matchups

### DIFF
--- a/Models/tournaments/matchup.ts
+++ b/Models/tournaments/matchup.ts
@@ -93,7 +93,7 @@ export class Matchup extends BaseEntity {
     @OneToMany(() => Matchup, matchup => matchup.winnerNextMatchup)
         winnerPreviousMatchups?: Matchup[] | null;
 
-    @OneToMany(() => MatchupMessage, message => message.matchup)
+    @OneToMany(() => MatchupMessage, message => message.matchup, { persistence: false })
         messages?: MatchupMessage[] | null;
 
     @Column({ type: "varchar", length: `http://255.255.255.255:65565`.length, nullable: true })


### PR DESCRIPTION
The following crash occured:  
![image](https://github.com/user-attachments/assets/bca6a0af-4b2c-4158-a414-eb744eed5191)

I am pretty certain it is caused by `matchup.save` being ran at the same time as `saveMessages`, as that's ran at 15 seconds interval and does seem to align.

Besides, `saveMessages` is ran using query builder so it can strictly only run `INSERT`, only `matchup.save` could lead to running such an UPDATE query. Even that is rather unclear though, because we *never* insert a message in `matchup.messages` without the matchup reference, so I don't why it would do that one.

But it's my only idea atm, and it's something that makes sense to do given we already save messages periodically and at the end of every matchup anyway.