### PR TITLE
Responsive Open site

### DIFF
--- a/Assets/components/footer/LanguageSwitcher.vue
+++ b/Assets/components/footer/LanguageSwitcher.vue
@@ -76,10 +76,7 @@ $selector-orange: #ff890a;
 .locale {
     display: flex;
     position: relative;
-    width: 40px;
-    @include breakpoint(laptop) {
-        width: 45px;
-    }
+    padding: 0px 8px;
 
     &__current {
         display: flex;

--- a/Assets/components/footer/TheFooter.vue
+++ b/Assets/components/footer/TheFooter.vue
@@ -73,5 +73,6 @@ export default class TheFooter extends Vue {
     width: 100%;
     height: 50px;
     display: flex;
+    justify-content: space-between;
 }
 </style>

--- a/Assets/components/header/TheHeader.vue
+++ b/Assets/components/header/TheHeader.vue
@@ -175,12 +175,11 @@ export default class TheHeader extends Vue {
 }
 
 .header-login {
-    position: relative;
+    height: 100%;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     justify-content: center;
-    margin-left: auto;
     
     @include breakpoint(mobile) {
         margin-right: 10px;

--- a/Assets/components/header/TheHeader.vue
+++ b/Assets/components/header/TheHeader.vue
@@ -191,6 +191,8 @@ export default class TheHeader extends Vue {
     
     &--open {
         color: $open-red;
+        flex-flow: row;
+        align-items: stretch;
     }
 
     &__welcome-container {

--- a/Assets/components/open/OpenFrontPageButton.vue
+++ b/Assets/components/open/OpenFrontPageButton.vue
@@ -71,7 +71,6 @@ export default class OpenFrontPageButton extends Vue {
 @import '@s-sass/_variables';
 
 .open_front_page_button {
-    margin: 50px 0px;
     height: 112px;
     color: $white;
 

--- a/Assets/components/open/OpenFrontPageButton.vue
+++ b/Assets/components/open/OpenFrontPageButton.vue
@@ -113,8 +113,8 @@ export default class OpenFrontPageButton extends Vue {
         height: 110px;
         background-color: $open-red;
 
-        &:hover {
-            text-decoration: none;
+        &:not(&--disabled):hover {
+            text-decoration: underline;
         }
 
         &--disabled {

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -294,6 +294,11 @@ export default class Default extends Mixins(CentrifugeMixin) {
 @import '@s-sass/_mixins';
 @import '@s-sass/_variables';
 
+.layout--open {
+    height: unset;
+    min-height: 100%;
+}
+
 .header {
     border-bottom: 1px solid $open-red;
     background-image: url("../../Assets/img/site/open/checkers.svg"), linear-gradient(0deg, white, white);

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -294,12 +294,6 @@ export default class Default extends Mixins(CentrifugeMixin) {
 @import '@s-sass/_mixins';
 @import '@s-sass/_variables';
 
-.layout--open {
-    height: unset;
-    min-height: 100%;
-    overflow: hidden;
-}
-
 .header {
     border-bottom: 1px solid $open-red;
     background: white;
@@ -308,7 +302,6 @@ export default class Default extends Mixins(CentrifugeMixin) {
     align-items: stretch;
     gap: 24px;
     width: 100vw;
-    position: fixed;
     z-index: 2;
     
     @include breakpoint(desktop) {
@@ -385,7 +378,6 @@ export default class Default extends Mixins(CentrifugeMixin) {
 }
 
 .footer {
-    position: fixed;
     z-index: 2;
 }
 
@@ -428,10 +420,5 @@ export default class Default extends Mixins(CentrifugeMixin) {
 .main {
     background-size: cover;
     overflow-x: hidden;
-    padding: 90px 0px 50px;
-
-    @include breakpoint(mobile) {
-        padding: 55px 0px 50px; // hardcoded for header breakpoint (sorry)
-    }
 }
 </style>

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -385,9 +385,7 @@ export default class Default extends Mixins(CentrifugeMixin) {
     height: 100%;
     display: flex;
     align-items: center;
-    @include breakpoint(mobile) {
-        margin-right: auto;
-    }
+    
     @include breakpoint(laptop) {
         margin-left: 20px;
     }

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -322,7 +322,7 @@ export default class Default extends Mixins(CentrifugeMixin) {
 
     &__logo {
         padding-left: 10px;
-        margin-top: 12px;
+        margin-top: 16px;
         
         @include breakpoint(mobile) {
             scale: 50%;

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -8,12 +8,12 @@
             class="header"
             :notif="teamInvites && teamInvites.length > 0"
         >
-            <a href="/">          
-                <img
-                    src="../../Assets/img/site/open/logo.png"
-                    class="header__logo"
-                    :class="`header__logo--${viewTheme}`"
-                >
+            <a 
+                href="/"
+                class="header__logo"
+                :class="`header__logo--${viewTheme}`"
+            >          
+                <img src="../../Assets/img/site/open/logo.png">
             </a>
 
             <div class="header__nav">
@@ -305,7 +305,7 @@ export default class Default extends Mixins(CentrifugeMixin) {
     background: white;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: stretch;
     gap: 24px;
     width: 100vw;
     position: fixed;
@@ -325,15 +325,27 @@ export default class Default extends Mixins(CentrifugeMixin) {
     }
 
     &__logo {
+        display: flex;
+        align-items: center;
+
         padding-left: 10px;
-        margin-top: 16px;
-        
+
         @include breakpoint(mobile) {
-            scale: 50%;
+            padding-left: 0px;
         }
 
         @include breakpoint(desktop) {
             padding-left: 130px;
+        }
+
+        & > img {
+            margin-top: 8px;
+
+            @include breakpoint(mobile) {
+                scale: 50%;
+                margin: -24px;
+                margin-top: -16px;
+            }
         }
     }
 
@@ -342,31 +354,27 @@ export default class Default extends Mixins(CentrifugeMixin) {
         display: flex;
         gap: 12px;
         flex: 1;
-        max-width: 1000px;
+        height: 100%;
+        max-width: 800px;
         justify-content: space-between;
-        align-items: center;
 
         &-item {
             font-weight: 600;
             text-decoration: none;
             color: $open-red;
+            display: flex;
+            align-items: center;
+            position: relative;
 
             &:hover {
-                color: $open-red;
-                text-decoration: none;
-            }
-
-            &.nuxt-link-exact-active {
-                color: $open-red;
-                position: relative;
-                display: inline-block;
+                text-decoration: underline;
             }
 
             &.nuxt-link-exact-active::after {
                 content: "";
                 position: absolute;
                 left: calc(50% - 4.5px/2);
-                bottom: -7px; 
+                bottom: calc(50% - 1em - 2px);
                 width: 4.5px;
                 height: 4.5px;
                 transform: rotate(-45deg);

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -214,10 +214,6 @@
                     {{ $t("open.footer.sheet") }}
                 </Tooltip>
             </div>
-            <div 
-                name="temp"
-                style="width: 79%;"
-            />
         </the-footer>
     </div>
 </template>

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -310,17 +310,17 @@ export default class Default extends Mixins(CentrifugeMixin) {
     }
 
     &__logo {
-        padding-left: 6px;
+        padding-left: 130px;
         margin-top: 27.5px;
-        @include breakpoint(tablet) {
-            padding-left: 7px;
-        }
-        @include breakpoint(laptop) {
-            padding-left: 9px;
-        }
-        @include breakpoint(desktop) {
-            padding-left: 130px;
-        }
+        // @include breakpoint(tablet) {
+        //     padding-left: 7px;
+        // }
+        // @include breakpoint(laptop) {
+        //     padding-left: 9px;
+        // }
+        // @include breakpoint(desktop) {
+        //     padding-left: 130px;
+        // }
     }
 
     &__nav {
@@ -328,6 +328,7 @@ export default class Default extends Mixins(CentrifugeMixin) {
         left: calc(30vw - 265px);
         align-self: center;
         display: flex;
+        gap: 12px;
         width: 40vw;
         justify-content: space-between;
         align-items: center;

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -301,11 +301,17 @@ export default class Default extends Mixins(CentrifugeMixin) {
 
 .header {
     border-bottom: 1px solid $open-red;
-    background-image: url("../../Assets/img/site/open/checkers.svg"), linear-gradient(0deg, white, white);
-    background-repeat: no-repeat;
-    background-position: left center;
+    background: white;
+    display: flex;
+    align-items: center;
     width: 100vw;
     position: relative;
+    
+    @include breakpoint(desktop) {
+        background-image: url("../../Assets/img/site/open/checkers.svg");
+        background-repeat: no-repeat;
+        background-position: left center;
+    }
 
     &__notification {
         width: 8px;
@@ -315,17 +321,16 @@ export default class Default extends Mixins(CentrifugeMixin) {
     }
 
     &__logo {
-        padding-left: 130px;
-        margin-top: 27.5px;
-        // @include breakpoint(tablet) {
-        //     padding-left: 7px;
-        // }
-        // @include breakpoint(laptop) {
-        //     padding-left: 9px;
-        // }
-        // @include breakpoint(desktop) {
-        //     padding-left: 130px;
-        // }
+        padding-left: 10px;
+        margin-top: 12px;
+        
+        @include breakpoint(mobile) {
+            scale: 50%;
+        }
+
+        @include breakpoint(desktop) {
+            padding-left: 130px;
+        }
     }
 
     &__nav {

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -303,7 +303,9 @@ export default class Default extends Mixins(CentrifugeMixin) {
     border-bottom: 1px solid $open-red;
     background: white;
     display: flex;
+    justify-content: space-between;
     align-items: center;
+    gap: 24px;
     width: 100vw;
     position: relative;
     
@@ -334,12 +336,9 @@ export default class Default extends Mixins(CentrifugeMixin) {
     }
 
     &__nav {
-        position: relative;
-        left: calc(30vw - 265px);
         align-self: center;
         display: flex;
         gap: 12px;
-        width: 40vw;
         justify-content: space-between;
         align-items: center;
 

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -341,6 +341,8 @@ export default class Default extends Mixins(CentrifugeMixin) {
         align-self: center;
         display: flex;
         gap: 12px;
+        flex: 1;
+        max-width: 1000px;
         justify-content: space-between;
         align-items: center;
 

--- a/Open/layouts/default.vue
+++ b/Open/layouts/default.vue
@@ -297,6 +297,7 @@ export default class Default extends Mixins(CentrifugeMixin) {
 .layout--open {
     height: unset;
     min-height: 100%;
+    overflow: hidden;
 }
 
 .header {
@@ -307,7 +308,8 @@ export default class Default extends Mixins(CentrifugeMixin) {
     align-items: center;
     gap: 24px;
     width: 100vw;
-    position: relative;
+    position: fixed;
+    z-index: 2;
     
     @include breakpoint(desktop) {
         background-image: url("../../Assets/img/site/open/checkers.svg");
@@ -372,6 +374,11 @@ export default class Default extends Mixins(CentrifugeMixin) {
     }
 }
 
+.footer {
+    position: fixed;
+    z-index: 2;
+}
+
 .socials {
     height: 100%;
     display: flex;
@@ -411,5 +418,10 @@ export default class Default extends Mixins(CentrifugeMixin) {
 .main {
     background-size: cover;
     overflow-x: hidden;
+    padding: 90px 0px 50px;
+
+    @include breakpoint(mobile) {
+        padding: 55px 0px 50px; // hardcoded for header breakpoint (sorry)
+    }
 }
 </style>

--- a/Open/pages/index.vue
+++ b/Open/pages/index.vue
@@ -163,6 +163,7 @@ export default class Default extends Vue {
 </script>
 
 <style lang="scss">
+@import '@s-sass/_mixins';
 @import '@s-sass/_variables';
 
 .index {
@@ -197,6 +198,11 @@ export default class Default extends Vue {
 
     &__banner {
         display: flex;
+        scale: 60%;
+
+        @include breakpoint(desktop) {
+            scale: 100%;
+        }
     }
 
     &_portal {

--- a/Open/pages/index.vue
+++ b/Open/pages/index.vue
@@ -190,7 +190,6 @@ export default class Default extends Vue {
         align-items: center;
         justify-content: center;
         overflow-y: auto;
-        padding: 50px;
         gap: 150px;
         width: 100%;
         flex: 1;

--- a/Open/pages/index.vue
+++ b/Open/pages/index.vue
@@ -171,14 +171,9 @@ export default class Default extends Vue {
     position: relative;
     overflow: hidden;
     text-align: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
 
     &__video {
         position: absolute;
-        top: 0;
-        left: 0;
         object-fit: cover;
         width: 100%;
         mask-image: linear-gradient(180deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0.75) 5%, rgba(19,19,19,0.5) 10%, rgba(19,19,19,0.25) 20%, rgba(19,19,19,0) 55%);

--- a/Open/pages/index.vue
+++ b/Open/pages/index.vue
@@ -173,14 +173,12 @@ export default class Default extends Vue {
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100%;
 
     &__video {
         position: absolute;
         top: 0;
         left: 0;
         object-fit: cover;
-        height: 100%;
         width: 100%;
         mask-image: linear-gradient(180deg, rgba(19,19,19,1) 0%, rgba(19,19,19,0.75) 5%, rgba(19,19,19,0.5) 10%, rgba(19,19,19,0.25) 20%, rgba(19,19,19,0) 55%);
     }
@@ -189,31 +187,39 @@ export default class Default extends Vue {
         position: relative;
         display: flex;
         flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        overflow-y: auto;
+        padding: 50px;
+        gap: 100px;
+        width: 100%;
+        flex: 1;
     }
 
     &__banner {
         display: flex;
-        align-self: center;
-        flex-direction: column;
-        margin-top: 50px;
-        gap: 50px;
     }
 
     &_portal {
-        margin-top: 100px;
         width: 80vw;
         display: flex;
-        flex-direction: row;
-        justify-content: space-between;
+        flex-flow: row wrap;
+        gap: 50px;
+        justify-content: center;
 
         &__section {
-            width: 25vw;
+            display: flex;
+            flex-flow: column;
+            gap: 50px;
+            flex: 1;
         }
 
         &__image {
             &--row {
                 display: flex;
-                justify-content: space-between;
+                justify-content: center;
+                flex-flow: row wrap;
+                gap: 24px;
                 padding: 25px 50px;
             }
 
@@ -225,7 +231,6 @@ export default class Default extends Vue {
     }
 
     &_schedule {
-        margin: 30px 0px;
         text-align: start;
         width: 75%;
 

--- a/Open/pages/index.vue
+++ b/Open/pages/index.vue
@@ -220,7 +220,7 @@ export default class Default extends Vue {
                 justify-content: center;
                 flex-flow: row wrap;
                 gap: 24px;
-                padding: 25px 50px;
+                padding: 25px;
             }
 
             & img {

--- a/Open/pages/index.vue
+++ b/Open/pages/index.vue
@@ -191,7 +191,7 @@ export default class Default extends Vue {
         justify-content: center;
         overflow-y: auto;
         padding: 50px;
-        gap: 100px;
+        gap: 150px;
         width: 100%;
         flex: 1;
     }


### PR DESCRIPTION
This PR includes changes for improving responsiveness on the Open website, mainly the Home page.

- [x] Fix language selector clipping through footer
- [x] Shift Home page layout on resize
- [x] Fix content clipping out of page on layout shift
- [x] Collapse header logo on resize
- [x] Scale and/or split banner on resize
- [ ] Move navigation links to menu on smaller viewports
- [ ] Disable viewport scaling